### PR TITLE
Add schedule contract docs, TypeScript interfaces, and slot-per-slot migration

### DIFF
--- a/database/migrations/20250919_add_schedule_slot_choice.sql
+++ b/database/migrations/20250919_add_schedule_slot_choice.sql
@@ -1,0 +1,16 @@
+CREATE TABLE schedule_slot_choice (
+    performer_id INTEGER NOT NULL,
+    concert_series VARCHAR(255) NOT NULL,
+    year INTEGER NOT NULL,
+    slot_id INTEGER NOT NULL,
+    rank INTEGER NULL,
+    not_available BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX schedule_slot_choice_unique_idx
+    ON schedule_slot_choice(performer_id, concert_series, year, slot_id);
+
+CREATE INDEX schedule_slot_choice_lookup_idx
+    ON schedule_slot_choice(performer_id, concert_series, year);

--- a/docs/schedule-contract.md
+++ b/docs/schedule-contract.md
@@ -1,0 +1,46 @@
+# Schedule Contract (Phase 0)
+
+## Mode selection
+
+* **confirm-only** when `slotCount === 1`.
+* **rank-choice** when `slotCount >= 2`.
+
+## Rank-choice invariants
+
+* Partial rankings are allowed (some slots may be unranked).
+* Exactly **one** slot must be ranked `1`.
+* Ranks must be unique (no duplicate ranks).
+* Rank values must be in the range `1..slotCount`.
+* `slotCount` is capped at **10** slots.
+
+## “Not available” semantics
+
+* `notAvailable` is persisted per slot.
+* `notAvailable` is **orthogonal** to ranking (a slot can be marked not available and left unranked, or ranked if allowed by future validation rules).
+* The value is stored independently of the rank field in the row-per-slot table.
+
+## Interfaces
+
+Source of truth lives in `src/lib/types/schedule.ts`.
+
+### Slot
+
+Represents a specific performance slot for a series/year, ordered by `concert_number_in_series`.
+
+### ScheduleChoice (domain)
+
+Represents a performer’s schedule choices in a normalized, slot-centric shape.
+
+### ScheduleViewModel
+
+Union of a **confirm-only** shape (single slot) and **rank-choice** shape (2–10 slots).
+
+### ScheduleSubmission
+
+Normalized server input used for validation and persistence.
+
+## Persistence (Phase 1 migration)
+
+A new row-per-slot table stores one row per performer/series/year/slot.
+
+See migration: `database/migrations/20250919_add_schedule_slot_choice.sql`.

--- a/src/lib/types/schedule.ts
+++ b/src/lib/types/schedule.ts
@@ -1,0 +1,53 @@
+export interface Slot {
+  id: number;
+  concertSeries: string;
+  year: number;
+  concertNumberInSeries: number;
+  startTime: string;
+  displayTime: string;
+}
+
+export interface ScheduleChoice {
+  performerId: number;
+  concertSeries: string;
+  year: number;
+  slots: Array<{
+    slotId: number;
+    rank: number | null;
+    notAvailable: boolean;
+  }>;
+}
+
+export type ScheduleViewModel =
+  | {
+      mode: 'confirm-only';
+      slotCount: 1;
+      slots: Array<{
+        slotId: number;
+        displayTime: string;
+        confirmed: boolean;
+        notAvailable: boolean;
+      }>;
+    }
+  | {
+      mode: 'rank-choice';
+      slotCount: number;
+      slots: Array<{
+        slotId: number;
+        displayTime: string;
+        rank: number | null;
+        notAvailable: boolean;
+      }>;
+      rankOptions: number[];
+    };
+
+export interface ScheduleSubmission {
+  performerId: number;
+  concertSeries: string;
+  year: number;
+  slots: Array<{
+    slotId: number;
+    rank: number | null;
+    notAvailable: boolean;
+  }>;
+}


### PR DESCRIPTION
### Motivation

- Establish the Phase 0 contract for the schedule refactor including mode selection and rank-choice invariants so subsequent implementation can be guided by a clear spec.  
- Make `notAvailable` a first-class persisted concept that is orthogonal to ranking so storage and validation can treat it explicitly.  
- Define canonical TypeScript interfaces so server and UI code can share a single source of truth for slots, view models, and submissions.  
- Prepare the database for Phase 1 by introducing a row-per-slot schema to enable slot-centric persistence.

### Description

- Added the contract/design doc at `docs/schedule-contract.md` documenting mode rules (`slotCount === 1 → confirm-only`, `slotCount ≥ 2 → rank-choice`), rank invariants, and `notAvailable` semantics.  
- Introduced TypeScript interfaces in `src/lib/types/schedule.ts`: `Slot`, `ScheduleChoice`, `ScheduleViewModel`, and `ScheduleSubmission` to normalize domain types.  
- Added a Phase 1 migration `database/migrations/20250919_add_schedule_slot_choice.sql` which creates `schedule_slot_choice` with columns `(performer_id, concert_series, year, slot_id, rank, not_available, created_at, updated_at)` and includes a uniqueness index and a lookup index.  
- No production runtime code paths were modified as part of this change (contract + schema only).

### Testing

- No automated tests were executed as part of this change because this deliverable covers spec and schema additions only.  
- The migration SQL is included in `database/migrations/20250919_add_schedule_slot_choice.sql` but was not applied to CI or a live database in this PR.  
- TypeScript interfaces were added as plain `.ts` files and no compilation or type-check run was performed by the automated pipeline for this commit.  
- Further unit and integration tests for `ScheduleValidator`, `ScheduleMapper`, `SlotCatalog`, and repository behavior will be added in subsequent phases per the task list.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952efb40d208326ba059eab8b5b6bd8)