### PR TITLE
Add SlotCatalog service to load and normalize concert slots

### DIFF
--- a/src/lib/server/slotCatalog.ts
+++ b/src/lib/server/slotCatalog.ts
@@ -1,0 +1,73 @@
+import { getCachedTimeStamps, type ConcertRow } from '$lib/cache';
+import { compareReformatISODate, displayReformatISODate } from '$lib/server/common';
+import { queryTable } from '$lib/server/db';
+import type { Slot } from '$lib/types/schedule';
+
+export type SlotSourceRow = {
+	concert_series: string;
+	year: number;
+	concert_number_in_series: number;
+	start_time: string;
+	normalizedStartTime?: string;
+	displayStartTime?: string;
+};
+
+export type SlotLoader = (concertSeries: string, year: number) => Promise<SlotSourceRow[]>;
+
+const defaultSlotLoader: SlotLoader = async () => {
+	const cached = getCachedTimeStamps();
+	if (cached?.data?.length) {
+		return cached.data;
+	}
+
+	const res = await queryTable('concert_times');
+	return (res.rows as ConcertRow[]).map((row) => ({
+		...row,
+		normalizedStartTime: compareReformatISODate(String(row.start_time)),
+		displayStartTime: displayReformatISODate(String(row.start_time))
+	}));
+};
+
+function normalizeSlot(row: SlotSourceRow): Slot {
+	const normalizedStartTime =
+		row.normalizedStartTime ?? compareReformatISODate(String(row.start_time));
+	const displayStartTime = row.displayStartTime ?? displayReformatISODate(String(row.start_time));
+
+	return {
+		id: row.concert_number_in_series,
+		concertSeries: row.concert_series,
+		year: row.year,
+		concertNumberInSeries: row.concert_number_in_series,
+		startTime: normalizedStartTime,
+		displayTime: displayStartTime
+	};
+}
+
+export class SlotCatalog {
+	readonly slots: Slot[];
+
+	constructor(slots: Slot[]) {
+		this.slots = slots;
+	}
+
+	get slotCount(): number {
+		return this.slots.length;
+	}
+
+	static async load(
+		concertSeries: string,
+		year: number,
+		options?: { loader?: SlotLoader }
+	): Promise<SlotCatalog> {
+		const loader = options?.loader ?? defaultSlotLoader;
+		const rows = await loader(concertSeries, year);
+
+		const slots = rows
+			.filter((row) => row.concert_series === concertSeries && row.year === year)
+			.slice()
+			.sort((a, b) => a.concert_number_in_series - b.concert_number_in_series)
+			.map((row) => normalizeSlot(row));
+
+		return new SlotCatalog(slots);
+	}
+}

--- a/src/test/lib/slotCatalog.test.ts
+++ b/src/test/lib/slotCatalog.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { SlotCatalog, type SlotSourceRow } from '$lib/server/slotCatalog';
+import { compareReformatISODate, displayReformatISODate } from '$lib/server/common';
+
+const baseYear = 2026;
+const series = 'Eastside';
+
+const makeRow = (concertNumber: number, startTime: string): SlotSourceRow => ({
+	concert_series: series,
+	year: baseYear,
+	concert_number_in_series: concertNumber,
+	start_time: startTime
+});
+
+describe('SlotCatalog', () => {
+	it('loads and normalizes a single slot', async () => {
+		const startTime = '05/03/2026T16:00:00';
+		const catalog = await SlotCatalog.load(series, baseYear, {
+			loader: async () => [makeRow(1, startTime)]
+		});
+
+		expect(catalog.slotCount).toBe(1);
+		expect(catalog.slots).toHaveLength(1);
+		expect(catalog.slots[0]).toMatchObject({
+			concertSeries: series,
+			year: baseYear,
+			concertNumberInSeries: 1,
+			startTime: compareReformatISODate(startTime),
+			displayTime: displayReformatISODate(startTime)
+		});
+	});
+
+	it('loads multiple slots sorted by concert number', async () => {
+		const rows = [
+			makeRow(3, '05/04/2026T14:00:00'),
+			makeRow(1, '05/03/2026T16:00:00'),
+			makeRow(2, '05/03/2026T19:00:00')
+		];
+
+		const catalog = await SlotCatalog.load(series, baseYear, {
+			loader: async () => rows
+		});
+
+		expect(catalog.slotCount).toBe(3);
+		expect(catalog.slots.map((slot) => slot.concertNumberInSeries)).toEqual([1, 2, 3]);
+	});
+
+	it('supports loading up to 10 slots', async () => {
+		const rows = Array.from({ length: 10 }, (_, index) =>
+			makeRow(index + 1, `05/${String(index + 1).padStart(2, '0')}/2026T10:00:00`)
+		).reverse();
+
+		const catalog = await SlotCatalog.load(series, baseYear, {
+			loader: async () => rows
+		});
+
+		expect(catalog.slotCount).toBe(10);
+		expect(catalog.slots.map((slot) => slot.concertNumberInSeries)).toEqual(
+			Array.from({ length: 10 }, (_, index) => index + 1)
+		);
+	});
+});


### PR DESCRIPTION
### Motivation
- Encapsulate slot loading and normalization behind a server-side service so page logic no longer reads DB/cache directly for slots.
- Provide a canonical, trusted ordering and count of slots for a given `(concert_series, year)` as required by the schedule refactor spec.
- Ensure timestamps are normalized for server-side validation and view model construction.

### Description
- Add `src/lib/server/slotCatalog.ts` implementing `SlotCatalog` with a static `load(concertSeries, year, options?)`, exposing `slots` and `slotCount` and normalizing `startTime` and `displayTime` using `compareReformatISODate` and `displayReformatISODate`.
- Provide a `SlotLoader` abstraction and a `defaultSlotLoader` that prefers the cache (`getCachedTimeStamps()`) and falls back to `queryTable('concert_times')` when necessary.
- Introduce `SlotSourceRow` type and map source rows to the `Slot` shape defined in `src/lib/types/schedule.ts` with ordering by `concert_number_in_series`.
- Add unit tests at `src/test/lib/slotCatalog.test.ts` covering single-slot, multi-slot ordering, and up-to-10-slot scenarios.

### Testing
- Ran `npm test -- slotCatalog.test.ts` and all tests passed (`3` tests across the file succeeded).
- Test run emitted a TS config warning (`./.svelte-kit/tsconfig.json` missing) but did not prevent the tests from succeeding.
- The unit tests validate slot loading, normalization of timestamps, and canonical ordering for `1`, multiple, and `10` slots.
- No UI or page code was modified in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952f1b30f148326afac793a8e6044fd)