### PR TITLE
Add ScheduleRepository for row-per-slot persistence and tests

### DIFF
--- a/src/lib/server/db.ts
+++ b/src/lib/server/db.ts
@@ -16,7 +16,7 @@ import {
 } from '$lib/server/common';
 import { isNonEmptyString } from '$lib/server/common';
 
-const pool = new Pool({
+export const pool = new Pool({
 	connectionString: DATABASE_URL,
 	ssl: DB_SSL === 'true' ? { rejectUnauthorized: false } : undefined
 });

--- a/src/lib/server/scheduleRepository.ts
+++ b/src/lib/server/scheduleRepository.ts
@@ -1,0 +1,86 @@
+import { pool } from '$lib/server/db';
+import type { ScheduleChoice } from '$lib/types/schedule';
+
+type ScheduleSlotChoiceRow = {
+	slot_id: number;
+	rank: number | null;
+	not_available: boolean;
+};
+
+export class ScheduleRepository {
+	async fetchChoices(
+		performerId: number,
+		concertSeries: string,
+		year: number
+	): Promise<ScheduleChoice | null> {
+		const connection = await pool.connect();
+		try {
+			const result = await connection.query<ScheduleSlotChoiceRow>(
+				`SELECT slot_id, rank, not_available
+         FROM schedule_slot_choice
+         WHERE performer_id = $1
+           AND concert_series = $2
+           AND year = $3
+         ORDER BY slot_id`,
+				[performerId, concertSeries, year]
+			);
+
+			if (!result.rowCount) {
+				return null;
+			}
+
+			return {
+				performerId,
+				concertSeries,
+				year,
+				slots: result.rows.map((row) => ({
+					slotId: row.slot_id,
+					rank: row.rank,
+					notAvailable: row.not_available
+				}))
+			};
+		} finally {
+			connection.release();
+		}
+	}
+
+	async upsertChoices(choice: ScheduleChoice): Promise<void> {
+		const connection = await pool.connect();
+		try {
+			await connection.query('BEGIN');
+			await connection.query(
+				`DELETE FROM schedule_slot_choice
+         WHERE performer_id = $1
+           AND concert_series = $2
+           AND year = $3`,
+				[choice.performerId, choice.concertSeries, choice.year]
+			);
+
+			const insertSQL = `INSERT INTO schedule_slot_choice
+        (performer_id, concert_series, year, slot_id, rank, not_available)
+       VALUES ($1, $2, $3, $4, $5, $6)
+       ON CONFLICT (performer_id, concert_series, year, slot_id)
+       DO UPDATE SET rank = EXCLUDED.rank,
+                    not_available = EXCLUDED.not_available,
+                    updated_at = NOW()`;
+
+			for (const slot of choice.slots) {
+				await connection.query(insertSQL, [
+					choice.performerId,
+					choice.concertSeries,
+					choice.year,
+					slot.slotId,
+					slot.rank,
+					slot.notAvailable
+				]);
+			}
+
+			await connection.query('COMMIT');
+		} catch (error) {
+			await connection.query('ROLLBACK');
+			throw error;
+		} finally {
+			connection.release();
+		}
+	}
+}

--- a/src/test/db/scheduleRepository.test.ts
+++ b/src/test/db/scheduleRepository.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { pool } from '$lib/server/db';
+import { ScheduleRepository } from '$lib/server/scheduleRepository';
+
+const repository = new ScheduleRepository();
+
+const performerId = 99991;
+const concertSeries = 'RepoTestSeries';
+const year = 2099;
+
+async function cleanup() {
+	const connection = await pool.connect();
+	try {
+		await connection.query(
+			`DELETE FROM schedule_slot_choice
+       WHERE performer_id = $1
+         AND concert_series = $2
+         AND year = $3`,
+			[performerId, concertSeries, year]
+		);
+	} finally {
+		connection.release();
+	}
+}
+
+describe('ScheduleRepository', () => {
+	afterEach(async () => {
+		await cleanup();
+	});
+
+	it('persists partial ranks', async () => {
+		await repository.upsertChoices({
+			performerId,
+			concertSeries,
+			year,
+			slots: [
+				{ slotId: 1, rank: 1, notAvailable: false },
+				{ slotId: 2, rank: null, notAvailable: false },
+				{ slotId: 3, rank: 2, notAvailable: false }
+			]
+		});
+
+		const stored = await repository.fetchChoices(performerId, concertSeries, year);
+		expect(stored).not.toBeNull();
+		expect(stored?.slots).toEqual([
+			{ slotId: 1, rank: 1, notAvailable: false },
+			{ slotId: 2, rank: null, notAvailable: false },
+			{ slotId: 3, rank: 2, notAvailable: false }
+		]);
+	});
+
+	it('persists not_available independently of rank', async () => {
+		await repository.upsertChoices({
+			performerId,
+			concertSeries,
+			year,
+			slots: [
+				{ slotId: 1, rank: 1, notAvailable: false },
+				{ slotId: 2, rank: null, notAvailable: true }
+			]
+		});
+
+		const stored = await repository.fetchChoices(performerId, concertSeries, year);
+		expect(stored?.slots).toEqual([
+			{ slotId: 1, rank: 1, notAvailable: false },
+			{ slotId: 2, rank: null, notAvailable: true }
+		]);
+	});
+
+	it('replaces prior rows when updating rankings', async () => {
+		await repository.upsertChoices({
+			performerId,
+			concertSeries,
+			year,
+			slots: [
+				{ slotId: 1, rank: 1, notAvailable: false },
+				{ slotId: 2, rank: 2, notAvailable: false },
+				{ slotId: 3, rank: null, notAvailable: true }
+			]
+		});
+
+		await repository.upsertChoices({
+			performerId,
+			concertSeries,
+			year,
+			slots: [
+				{ slotId: 1, rank: 1, notAvailable: false },
+				{ slotId: 2, rank: null, notAvailable: false }
+			]
+		});
+
+		const stored = await repository.fetchChoices(performerId, concertSeries, year);
+		expect(stored?.slots).toEqual([
+			{ slotId: 1, rank: 1, notAvailable: false },
+			{ slotId: 2, rank: null, notAvailable: false }
+		]);
+	});
+});


### PR DESCRIPTION
### Motivation

- Implement Phase 2 Deliverable 3 from the schedule refactor to provide server-side persistence for row-per-slot schedule choices.  
- Provide a pure persistence layer (no business validation) that can fetch existing choices and upsert rows per slot.  
- Ensure `rank` and `not_available` are first-class persisted fields per slot as required by the new schema.  
- Prepare for later phases by exposing a shared DB pool usable by repository classes.

### Description

- Export the shared database pool by changing `pool` to `export const pool` in `src/lib/server/db.ts`.  
- Add `ScheduleRepository` (`src/lib/server/scheduleRepository.ts`) with `fetchChoices(performerId, concertSeries, year)` that returns a normalized `ScheduleChoice` and `upsertChoices(choice)` that writes rows per slot inside a transaction.  
- `upsertChoices` deletes existing rows for the performer/series/year and inserts the provided slot rows, using `ON CONFLICT` to update `rank`, `not_available`, and `updated_at`.  
- Add unit tests (`src/test/db/scheduleRepository.test.ts`) that assert partial ranks persist, `not_available` persists independently of rank, and updates replace prior rows cleanly.

### Testing

- Added unit tests in `src/test/db/scheduleRepository.test.ts` that cover partial ranks, `not_available` behavior, and update/replace semantics.  
- Tests exercise `ScheduleRepository.upsertChoices` and `ScheduleRepository.fetchChoices` against the `schedule_slot_choice` table.  
- No automated test run was executed as part of this change (tests were added but not executed here).  
- To run the test suite locally, execute the project test command such as `npm test` (or your preferred test runner command).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954890090b4832689d8368bcf38d861)