### PR TITLE
Add slot-driven ScheduleMapper

### DIFF
--- a/src/lib/server/scheduleMapper.ts
+++ b/src/lib/server/scheduleMapper.ts
@@ -13,12 +13,15 @@ const fieldNames = {
 	confirm: (slotId: number) => `slot-${slotId}-confirm`
 };
 
-function coerceRank(value: FormDataEntryValue | null): number | null {
+function coerceRank(value: FormDataEntryValue | null, slotCount: number): number | null {
 	if (typeof value !== 'string' || value.trim() === '') {
 		return null;
 	}
 	const numeric = Number(value);
 	if (!Number.isInteger(numeric)) {
+		return null;
+	}
+	if (numeric < 1 || numeric > slotCount) {
 		return null;
 	}
 	return numeric;
@@ -96,7 +99,7 @@ export class ScheduleMapper {
 					};
 				}
 
-				const rankValue = coerceRank(formData.get(fieldNames.rank(slot.id)));
+				const rankValue = coerceRank(formData.get(fieldNames.rank(slot.id)), slotCount);
 				return {
 					slotId: slot.id,
 					rank: notAvailable ? null : rankValue,

--- a/src/test/lib/scheduleMapper.test.ts
+++ b/src/test/lib/scheduleMapper.test.ts
@@ -126,6 +126,7 @@ describe('ScheduleMapper', () => {
 		formData.set(scheduleFieldNames.rank(2), '');
 		formData.set(scheduleFieldNames.rank(3), '2');
 		formData.set(scheduleFieldNames.notAvailable(2), 'on');
+		formData.set(scheduleFieldNames.rank(4), '99');
 
 		const submission = ScheduleMapper.fromFormData(formData, {
 			...baseContext,


### PR DESCRIPTION
### Motivation

- Implement a slot-driven mapper to support the refactored schedule flow where UI mode is determined by slot count rather than series name.
- Provide a single canonical translation layer between DB rows, the UI view model, and form payloads so server can fully hydrate UI state without Svelte logic.
- Handle persisted partial rankings, explicit "not available" flags, and empty/previously-saved states uniformly.
- Prepare for rank-choice support up to 10 slots and confirm-only behavior for single-slot series.

### Description

- Add `src/lib/server/scheduleMapper.ts` which implements `ScheduleMapper.toViewModel` and `ScheduleMapper.fromFormData` with slot-driven behavior and exported `scheduleFieldNames` helpers.
- Mapper supports both modes: `confirm-only` when `slotCount === 1` and `rank-choice` otherwise, and produces `ScheduleViewModel` / `ScheduleSubmission` shapes from `Slot[]` and `FormData` inputs.
- Mapping handles empty state, previously-saved partial ranks, and mixed rank + not-available scenarios via `buildSlotLookup` and `coerceRank` helpers.
- Add unit tests at `src/test/lib/scheduleMapper.test.ts` covering confirm-only and rank-choice cases (2, 4, 10 slots), form→submission mapping, and mixed availability scenarios.

### Testing

- Added unit tests for the mapper under `src/test/lib/scheduleMapper.test.ts` that exercise `toViewModel` and `fromFormData` for confirm-only and rank-choice modes.
- No automated tests were executed as part of this change (tests were added but not run in this rollout).
- To run the test suite locally use `npm test` (or `vitest`) to execute the new mapper tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695492987df08326855142fa7225a304)