### PR TITLE
Introduce PerformerLookup and ScheduleValidator; refactor schedule server flow to use SlotCatalog/ScheduleRepository/ScheduleMapper

### DIFF
--- a/src/lib/server/performerLookup.ts
+++ b/src/lib/server/performerLookup.ts
@@ -1,0 +1,120 @@
+import DOMPurify from 'dompurify';
+import { JSDOM } from 'jsdom';
+import { isNonEmptyString, type PerformerSearchResultsInterface } from '$lib/server/common';
+import { lookupByCode, lookupByDetails } from '$lib/server/db';
+
+type LookupStatus = PerformerSearchResultsInterface['status'];
+
+const baseResult = (status: LookupStatus): PerformerSearchResultsInterface => ({
+	status,
+	performer_id: 0,
+	performer_name: '',
+	musical_piece: '',
+	lottery_code: 0,
+	concert_series: '',
+	performance_id: 0,
+	performance_duration: 0,
+	performance_comment: null
+});
+
+export class PerformerLookup {
+	private purify: DOMPurify.DOMPurifyI;
+
+	private constructor(purify: DOMPurify.DOMPurifyI) {
+		this.purify = purify;
+	}
+
+	static create(): PerformerLookup {
+		const window = new JSDOM('').window;
+		return new PerformerLookup(DOMPurify(window));
+	}
+
+	private sanitize(value: string): string {
+		return this.purify.sanitize(value);
+	}
+
+	private mapSuccess(result: PerformerSearchResultsInterface): PerformerSearchResultsInterface {
+		return {
+			status: 'OK',
+			performer_id: result.performer_id,
+			performer_name: result.performer_name,
+			musical_piece: result.musical_piece,
+			lottery_code: result.lottery_code,
+			concert_series: result.concert_series,
+			performance_id: result.performance_id,
+			performance_duration: result.performance_duration,
+			performance_comment: result.performance_comment
+		};
+	}
+
+	private mapNotFound(overrides?: Partial<PerformerSearchResultsInterface>): PerformerSearchResultsInterface {
+		return {
+			...baseResult('NOTFOUND'),
+			...overrides
+		};
+	}
+
+	private mapError(): PerformerSearchResultsInterface {
+		return baseResult('ERROR');
+	}
+
+	async lookupByCode(code: string): Promise<PerformerSearchResultsInterface> {
+		try {
+			const result = await lookupByCode(code);
+			if (!result) {
+				return this.mapNotFound({ lottery_code: Number(code) });
+			}
+			return this.mapSuccess(result);
+		} catch {
+			return this.mapError();
+		}
+	}
+
+	async lookupByDetails(
+		performerLastName: string,
+		age: number,
+		composerName: string
+	): Promise<PerformerSearchResultsInterface> {
+		try {
+			const result = await lookupByDetails(performerLastName, age, composerName);
+			if (!result) {
+				return this.mapNotFound({ performer_name: performerLastName });
+			}
+			return this.mapSuccess(result);
+		} catch {
+			return this.mapError();
+		}
+	}
+
+	async lookupFromUrl(url: URL): Promise<PerformerSearchResultsInterface> {
+		const codeParam = url.searchParams.get('code');
+		if (codeParam != null && isNonEmptyString(codeParam)) {
+			const code = this.sanitize(codeParam);
+			return this.lookupByCode(code);
+		}
+
+		const lastNameParam = url.searchParams.get('performerLastName');
+		const ageParam = url.searchParams.get('age');
+		const composerParam = url.searchParams.get('composerName');
+
+		if (
+			lastNameParam != null &&
+			isNonEmptyString(lastNameParam) &&
+			ageParam != null &&
+			isNonEmptyString(ageParam) &&
+			composerParam != null &&
+			isNonEmptyString(composerParam)
+		) {
+			const performerLastName = this.sanitize(lastNameParam);
+			const composerName = this.sanitize(composerParam);
+			const ageValue = Number.parseInt(this.sanitize(ageParam), 10);
+			if (!Number.isInteger(ageValue)) {
+				return this.mapNotFound({ performer_name: performerLastName });
+			}
+
+			return this.lookupByDetails(performerLastName, ageValue, composerName);
+		}
+
+		return this.mapNotFound();
+	}
+}

--- a/src/lib/server/scheduleValidator.ts
+++ b/src/lib/server/scheduleValidator.ts
@@ -1,0 +1,80 @@
+import type { ScheduleSubmission } from '$lib/types/schedule';
+
+export type ScheduleValidationResult = {
+	valid: boolean;
+	errors: string[];
+};
+
+export class ScheduleValidator {
+	static validate(submission: ScheduleSubmission, slotCount: number): ScheduleValidationResult {
+		const errors: string[] = [];
+
+		if (slotCount <= 0) {
+			errors.push('No schedule slots available.');
+			return { valid: false, errors };
+		}
+
+		if (submission.slots.length !== slotCount) {
+			errors.push('Schedule payload does not match available slots.');
+		}
+
+		if (slotCount === 1) {
+			const slot = submission.slots[0];
+			if (!slot) {
+				errors.push('Confirmation selection is required.');
+				return { valid: false, errors };
+			}
+
+			if (slot.notAvailable) {
+				return { valid: errors.length === 0, errors };
+			}
+
+			if (slot.rank !== 1) {
+				errors.push('Confirmation selection is required.');
+			}
+
+			return { valid: errors.length === 0, errors };
+		}
+
+		const ranks: number[] = [];
+		for (const slot of submission.slots) {
+			if (slot.notAvailable) {
+				if (slot.rank != null) {
+					errors.push('Not-available selections cannot include a rank.');
+				}
+				continue;
+			}
+
+			if (slot.rank == null) {
+				continue;
+			}
+
+			if (!Number.isInteger(slot.rank)) {
+				errors.push('Rank selections must be integers.');
+				continue;
+			}
+
+			if (slot.rank < 1 || slot.rank > slotCount) {
+				errors.push('Rank selections must be within the available slot range.');
+				continue;
+			}
+
+			ranks.push(slot.rank);
+		}
+
+		if (ranks.length === 0) {
+			errors.push('No choices found please submit again with at least one ranked choice');
+		}
+
+		const uniqueRanks = new Set(ranks);
+		if (uniqueRanks.size !== ranks.length) {
+			errors.push('Duplicate rankings selected.');
+		}
+
+		if (!uniqueRanks.has(1)) {
+			errors.push('At least one slot must be ranked as first choice.');
+		}
+
+		return { valid: errors.length === 0, errors };
+	}
+}

--- a/src/routes/schedule/+page.server.ts
+++ b/src/routes/schedule/+page.server.ts
@@ -1,21 +1,18 @@
 import { fail, redirect } from '@sveltejs/kit';
-import DOMPurify from 'dompurify';
-import { JSDOM } from 'jsdom';
 import {
 	type PerformerSearchResultsInterface,
 	isNonEmptyString,
 	year,
-	type ScheduleFormInterface,
-	compareReformatISODate
+	type ScheduleFormInterface
 } from '$lib/server/common';
-import {
-	createDBSchedule,
-	lookupByCode,
-	lookupByDetails,
-	selectDBSchedule,
-	updateConcertPerformance
-} from '$lib/server/db';
+import { updateConcertPerformance } from '$lib/server/db';
+import { PerformerLookup } from '$lib/server/performerLookup';
+import { ScheduleMapper, scheduleFieldNames } from '$lib/server/scheduleMapper';
+import { ScheduleRepository } from '$lib/server/scheduleRepository';
+import { ScheduleValidator } from '$lib/server/scheduleValidator';
+import { SlotCatalog } from '$lib/server/slotCatalog';
 import { getCachedTimeStamps, type ConcertRow } from '$lib/cache';
+import type { ScheduleViewModel, Slot } from '$lib/types/schedule';
 
 // Ensure a stable ordering of concert times for both rendering and form processing
 function getSortedConcertTimes(): ConcertRow[] | null {
@@ -34,220 +31,85 @@ function getSortedConcertTimes(): ConcertRow[] | null {
 		});
 }
 
-function parseRankChoice(choice: string | null): number | null {
-	if (!choice || choice === '') {
-		return null;
-	}
-	const rankNumber = Number(choice);
-	if (Number.isInteger(rankNumber) && rankNumber > 0 && rankNumber < 5) {
-		return rankNumber;
-	} else {
-		return null;
-	}
+const legacyRankFields = [
+	'rank-sat-first',
+	'rank-sat-second',
+	'rank-sun-third',
+	'rank-sun-fourth'
+];
+const legacyNotAvailableFields = [
+	'nonviable-sat-first',
+	'nonviable-sat-second',
+	'nonviable-sun-third',
+	'nonviable-sun-fourth'
+];
+
+function hasLegacyScheduleFields(formData: FormData): boolean {
+	return (
+		formData.has('concert-confirm') ||
+		legacyRankFields.some((field) => formData.has(field)) ||
+		legacyNotAvailableFields.some((field) => formData.has(field))
+	);
 }
 
-function createRankedChoiceTimestamps(
-	notAvailableFirstConcert: boolean,
-	notAvailableSecondConcert: boolean,
-	notAvailableThirdConcert: boolean,
-	notAvailableFourthConcert: boolean,
-	firstConcertRankChoice: number | null,
-	secondConcertRankChoice: number | null,
-	thirdConcertRankChoice: number | null,
-	fourthConcertRankChoice: number | null
-): string[] {
-	const concertStartTimes = getSortedConcertTimes();
-	if (!concertStartTimes) {
-		return [];
-	}
-	const concertTimeStamps: string[] = concertStartTimes
-		.filter((concert) => concert.concert_series !== 'Concerto') // Eastside Only
-		.map((concert) => concert.normalizedStartTime);
-
-	// initialize what we will return
-	const rankedConcertTimeStamps: (string | null)[] = [null, null, null, null];
-	// consolidate not available and rank into single field
-	const rankedChoices: (number | null)[] = [
-		notAvailableFirstConcert ? null : firstConcertRankChoice,
-		notAvailableSecondConcert ? null : secondConcertRankChoice,
-		notAvailableThirdConcert ? null : thirdConcertRankChoice,
-		notAvailableFourthConcert ? null : fourthConcertRankChoice
-	];
-
-	// the rank is 1-4 a priority for each concert in series
-	// the lowest ranked (#1) timestamp goes in the beginning of the array
-	// the higher ranked timestamps are push on inorder
-	for (const [index, rank] of rankedChoices.entries()) {
-		if (rank) {
-			rankedConcertTimeStamps[rank - 1] = concertTimeStamps[index];
-		}
-	}
-
-	// compact and remove the nulls
-	// now that we have the timestamps that is all we need
-	// this filter also removed gaps if the user had non-contiguous ranks
-	return rankedConcertTimeStamps.filter((value): value is string => value != null);
+function hasModernScheduleFields(formData: FormData, slots: Slot[]): boolean {
+	return slots.some(
+		(slot) =>
+			formData.has(scheduleFieldNames.rank(slot.id)) ||
+			formData.has(scheduleFieldNames.notAvailable(slot.id)) ||
+			formData.has(scheduleFieldNames.confirm(slot.id))
+	);
 }
 
-function timestampsToFormValues(
-	concert_series: string,
-	timestamps: string[]
-): ScheduleFormInterface[] {
-	const concertStartTimes = getSortedConcertTimes();
-	const defaultFormData: ScheduleFormInterface[] = [
-		{ rank: null, notSelected: true },
-		{ rank: null, notSelected: true },
-		{ rank: null, notSelected: true },
-		{ rank: null, notSelected: true }
-	];
-
-	if (!concertStartTimes) {
-		return defaultFormData;
-	}
-
-	if (concert_series === 'Concerto') {
-		// get concerto start time from cache
-		const starttime: string | undefined = concertStartTimes.find(
-			(concert) => concert.concert_series === 'Concerto'
-		)?.normalizedStartTime;
-		if (compareReformatISODate(timestamps[0]) === starttime) {
-			return [{ confirmed: true }];
+function normalizeLegacyScheduleForm(formData: FormData, slots: Slot[]): FormData {
+	const normalized = new FormData();
+	if (slots.length === 1) {
+		if (formData.get('concert-confirm') !== null) {
+			normalized.set(scheduleFieldNames.confirm(slots[0].id), 'on');
 		}
+		return normalized;
 	}
 
-	const mapTimesToRanks = new Map<string, number>();
-
-	concertStartTimes.forEach((concert) => {
-		if (concert.concert_series !== 'Concerto') {
-			mapTimesToRanks.set(concert.normalizedStartTime, concert.concert_number_in_series);
+	slots.forEach((slot, index) => {
+		const rankField = legacyRankFields[index];
+		const notAvailableField = legacyNotAvailableFields[index];
+		if (rankField) {
+			const value = formData.get(rankField);
+			if (typeof value === 'string') {
+				normalized.set(scheduleFieldNames.rank(slot.id), value);
+			}
+		}
+		if (notAvailableField && formData.get(notAvailableField) !== null) {
+			normalized.set(scheduleFieldNames.notAvailable(slot.id), 'on');
 		}
 	});
 
-	// init array
-	const formData: ScheduleFormInterface[] = defaultFormData.map((entry) => ({ ...entry }));
-	/*
-	 * formData has an entry for each possible concert ordered chronologically
-	 * The first element for formData represents the first concert, the second element
-	 * represents the second concert etc
-	 * The timestamps passed in are concert times in order of preference
-	 * The first element in timestamps represents the most desired concert slot,
-	 * while the fourth element in timestamps represents the least desired concert slot
-	 * The array of timestamps must contain at least one value
-	 *
-	 */
-	for (const [index, value] of timestamps.entries()) {
-		if (value) {
-			// map the timestamp to a concert in the series
-			const concertNumberInSeries = mapTimesToRanks.get(compareReformatISODate(value));
-			// set the nth element in the form to the rank conferred by the index
-			// for example the first element of timestamps might be the 4th concert in the series
-			// that means the 4th concert is the most desirable and should have rank 1
-			// index start from zero so we need to add one
-			// concert series minus one to map back to array indexes which start at zero
-			if (concertNumberInSeries) {
-				formData[concertNumberInSeries - 1].rank = index + 1;
-				formData[concertNumberInSeries - 1].notSelected = false;
-			}
-		}
+	return normalized;
+}
+
+function resolveScheduleFormData(formData: FormData, slots: Slot[]): FormData {
+	if (hasModernScheduleFields(formData, slots)) {
+		return formData;
+	}
+	if (hasLegacyScheduleFields(formData)) {
+		return normalizeLegacyScheduleForm(formData, slots);
 	}
 	return formData;
 }
 
-async function retrievePerformerByCode(code: string): Promise<PerformerSearchResultsInterface> {
-	try {
-		const result: PerformerSearchResultsInterface | null = await lookupByCode(code);
-		if (result == null) {
-			return {
-				status: 'NOTFOUND',
-				performer_id: 0,
-				performer_name: '',
-				musical_piece: '',
-				lottery_code: Number(code),
-				concert_series: '',
-				performance_id: 0,
-				performance_duration: 0,
-				performance_comment: null
-			};
-		}
-		return {
-			status: 'OK',
-			performer_id: result.performer_id,
-			performer_name: result.performer_name,
-			musical_piece: result.musical_piece,
-			lottery_code: result.lottery_code,
-			concert_series: result.concert_series,
-			performance_id: result.performance_id,
-			performance_duration: result.performance_duration,
-			performance_comment: result.performance_comment
-		};
-	} catch {
-		return {
-			status: 'ERROR',
-			performer_id: 0,
-			performer_name: '',
-			musical_piece: '',
-			lottery_code: 0,
-			concert_series: '',
-			performance_id: 0,
-			performance_duration: 0,
-			performance_comment: null
-		};
+function toLegacyFormValues(viewModel: ScheduleViewModel): ScheduleFormInterface[] {
+	if (viewModel.mode === 'confirm-only') {
+		const confirmed = viewModel.slots[0]?.confirmed ?? false;
+		return [{ confirmed }];
 	}
-}
-async function retrievePerformerByDetails(
-	performerLastName: string,
-	age: number,
-	composerName: string
-): Promise<PerformerSearchResultsInterface> {
-	try {
-		const result: PerformerSearchResultsInterface | null = await lookupByDetails(
-			performerLastName,
-			age,
-			composerName
-		);
-		if (result == null) {
-			return {
-				status: 'NOTFOUND',
-				performer_id: 0,
-				performer_name: performerLastName,
-				musical_piece: '',
-				lottery_code: 0,
-				concert_series: '',
-				performance_id: 0,
-				performance_duration: 0,
-				performance_comment: null
-			};
-		}
-		return {
-			status: 'OK',
-			performer_id: result.performer_id,
-			performer_name: result.performer_name,
-			musical_piece: result.musical_piece,
-			lottery_code: result.lottery_code,
-			concert_series: result.concert_series,
-			performance_id: result.performance_id,
-			performance_duration: result.performance_duration,
-			performance_comment: result.performance_comment
-		};
-	} catch {
-		return {
-			status: 'ERROR',
-			performer_id: 0,
-			performer_name: '',
-			musical_piece: '',
-			lottery_code: 0,
-			concert_series: '',
-			performance_id: 0,
-			performance_duration: 0,
-			performance_comment: null
-		};
-	}
+	return viewModel.slots.map((slot) => ({
+		rank: slot.rank ?? null,
+		notSelected: slot.notAvailable
+	}));
 }
 
 export async function load({ url }) {
-	// setup purify to clean out any injected JS
-	const window = new JSDOM('').window;
-	const purify = DOMPurify(window);
+	const performerLookup = PerformerLookup.create();
 	let performerSearchResults: PerformerSearchResultsInterface = {
 		status: 'ERROR',
 		performer_id: 0,
@@ -259,7 +121,10 @@ export async function load({ url }) {
 		performance_duration: 0,
 		performance_comment: null
 	};
-	let formValues = null;
+	let formValues: ScheduleFormInterface[] | null = null;
+	let viewModel: ScheduleViewModel | null = null;
+	let slotCount = 0;
+	let slots: Slot[] = [];
 
 	const concertStartTimes = getSortedConcertTimes();
 	if (concertStartTimes == null) {
@@ -278,101 +143,45 @@ export async function load({ url }) {
 		};
 	}
 
-	if (url.searchParams.get('code') != null && isNonEmptyString(url.searchParams.get('code'))) {
-		const code = purify.sanitize(url.searchParams.get('code')!);
-		performerSearchResults = await retrievePerformerByCode(code);
-		if (performerSearchResults.status != 'OK') {
-			return {
-				status: performerSearchResults.status,
-				performer_id: performerSearchResults.performer_id,
-				performer_name: performerSearchResults.performer_name,
-				musical_piece: performerSearchResults.musical_piece,
-				lottery_code: performerSearchResults.lottery_code,
-				concert_series: performerSearchResults.concert_series,
-				formValues: null,
-				concertTimes: concertStartTimes,
-				performance_id: performerSearchResults.performance_id,
-				performance_duration: performerSearchResults.performance_duration,
-				performance_comment: performerSearchResults.performance_comment
-			};
-		}
-	} else {
-		if (
-			url.searchParams.get('performerLastName') != null &&
-			isNonEmptyString(url.searchParams.get('performerLastName')) &&
-			url.searchParams.get('age') != null &&
-			isNonEmptyString(url.searchParams.get('age')) &&
-			url.searchParams.get('composerName') != null &&
-			isNonEmptyString(url.searchParams.get('composerName'))
-		) {
-			const performerLastName = purify.sanitize(url.searchParams.get('performerLastName')!);
-			const ageString = purify.sanitize(url.searchParams.get('age')!);
-			const age = parseInt(ageString, 10);
-			const composerName = purify.sanitize(url.searchParams.get('composerName')!);
-			performerSearchResults = await retrievePerformerByDetails(
-				performerLastName,
-				age,
-				composerName
-			);
-			if (performerSearchResults.status != 'OK') {
-				return {
-					status: performerSearchResults.status,
-					performer_id: performerSearchResults.performer_id,
-					performer_name: performerSearchResults.performer_name,
-					musical_piece: performerSearchResults.musical_piece,
-					lottery_code: performerSearchResults.lottery_code,
-					concert_series: performerSearchResults.concert_series,
-					formValues: null,
-					concertTimes: concertStartTimes,
-					performance_id: performerSearchResults.performance_id,
-					performance_duration: performerSearchResults.performance_duration,
-					performance_comment: performerSearchResults.performance_comment
-				};
-			}
-		} else {
-			return {
-				status: 'NOTFOUND',
-				performer_id: 0,
-				performer_name: '',
-				musical_piece: '',
-				lottery_code: '',
-				concert_series: '',
-				formValues: null,
-				concertTimes: null,
-				performance_id: 0,
-				performance_duration: 0,
-				performance_comment: null
-			};
-		}
-	}
+	performerSearchResults = await performerLookup.lookupFromUrl(url);
+	if (performerSearchResults.status === 'OK') {
+		const slotCatalog = await SlotCatalog.load(
+			performerSearchResults.concert_series,
+			year()
+		);
+		slotCount = slotCatalog.slotCount;
+		slots = slotCatalog.slots;
 
-	// found performer id now see if schedule already exists
-	try {
-		const scheduleRes = await selectDBSchedule(performerSearchResults.performer_id, year());
-		if (scheduleRes.rowCount != null && scheduleRes.rowCount > 0) {
-			formValues = timestampsToFormValues(scheduleRes.rows[0].concert_series, [
-				scheduleRes.rows[0].first_choice_time,
-				scheduleRes.rows[0].second_choice_time,
-				scheduleRes.rows[0].third_choice_time,
-				scheduleRes.rows[0].fourth_choice_time
-			]);
+		if (slotCount > 0) {
+			const scheduleRepository = new ScheduleRepository();
+			try {
+				const scheduleChoice = await scheduleRepository.fetchChoices(
+					performerSearchResults.performer_id,
+					performerSearchResults.concert_series,
+					year()
+				);
+				viewModel = ScheduleMapper.toViewModel(slotCatalog.slots, scheduleChoice);
+				formValues = toLegacyFormValues(viewModel);
+			} catch {
+				console.error('Error performing fetchSchedule');
+			}
 		}
-	} catch {
-		// eat the error performer can resubmit
-		console.error('Error performing fetchSchedule');
 	}
 	return {
-		status: 'OK',
+		status: performerSearchResults.status,
 		performer_id: performerSearchResults.performer_id,
 		performer_name: performerSearchResults.performer_name,
 		musical_piece: performerSearchResults.musical_piece,
 		lottery_code: performerSearchResults.lottery_code,
 		concert_series: performerSearchResults.concert_series,
-		formValues: formValues,
+		formValues,
 		concertTimes: concertStartTimes,
 		performance_id: performerSearchResults.performance_id,
 		performance_duration: performerSearchResults.performance_duration,
-		performance_comment: performerSearchResults.performance_comment
+		performance_comment: performerSearchResults.performance_comment,
+		viewModel,
+		slotCount,
+		slots
 	};
 }
 
@@ -406,82 +215,26 @@ export const actions = {
 				await updateConcertPerformance(performanceIdAsNumber, duration, comment);
 			}
 
-			if (concertSeries.toLowerCase() === 'concerto') {
-				// get concerto start time from cache
-				const concertStartTimes = getSortedConcertTimes();
-				const starttime: string | undefined = concertStartTimes?.find(
-					(concert) => concert.concert_series === 'Concerto'
-				)?.normalizedStartTime;
-				if (starttime === undefined) {
-					return fail(500, { error: 'unable to retrieve Concerto starttime from Cache' });
-				}
-				const results = await createDBSchedule(
-					performerIdAsNumber,
-					concertSeries,
-					year(),
-					starttime,
-					null,
-					null,
-					null
-				);
-				if (results.rowCount != null && results.rowCount > 0) {
-					throw redirect(303, '/');
-				} else {
-					return fail(500, { error: 'unable to confirm Concerto schedule please try again' });
-				}
-			} else if (concertSeries.toLowerCase() === 'eastside') {
-				const notAvailableFirstConcert = !!formData.get('nonviable-sat-first');
-				const notAvailableSecondConcert = !!formData.get('nonviable-sat-second');
-				const notAvailableThirdConcert = !!formData.get('nonviable-sun-third');
-				const notAvailableFourthConcert = !!formData.get('nonviable-sun-fourth');
-
-				// parse is important it validates numbers are between 0 and 3 our array index
-				const firstConcertRankChoice: number | null = parseRankChoice(
-					formData.get('rank-sat-first') ? String(formData.get('rank-sat-first')) : null
-				);
-				const secondConcertRankChoice: number | null = parseRankChoice(
-					formData.get('rank-sat-second') ? String(formData.get('rank-sat-second')) : null
-				);
-				const thirdConcertRankChoice: number | null = parseRankChoice(
-					formData.get('rank-sun-third') ? String(formData.get('rank-sun-third')) : null
-				);
-				const fourthConcertRankChoice: number | null = parseRankChoice(
-					formData.get('rank-sun-fourth') ? String(formData.get('rank-sun-fourth')) : null
-				);
-
-				const rankedChoiceTimeStamps = createRankedChoiceTimestamps(
-					notAvailableFirstConcert,
-					notAvailableSecondConcert,
-					notAvailableThirdConcert,
-					notAvailableFourthConcert,
-					firstConcertRankChoice,
-					secondConcertRankChoice,
-					thirdConcertRankChoice,
-					fourthConcertRankChoice
-				);
-				if (rankedChoiceTimeStamps[0] != null) {
-					const results = await createDBSchedule(
-						performerIdAsNumber,
-						concertSeries,
-						year(),
-						rankedChoiceTimeStamps[0],
-						rankedChoiceTimeStamps[1],
-						rankedChoiceTimeStamps[2],
-						rankedChoiceTimeStamps[3]
-					);
-					if (results.rowCount != null && results.rowCount > 0) {
-						throw redirect(303, '/');
-					}
-				} else {
-					return fail(400, {
-						error: 'No choices found please submit again with at least one ranked choice'
-					});
-				}
-			} else {
-				return fail(400, {
-					error: `Unknown concert series ${concertSeries} expected Eastside or Concerto`
-				});
+			const slotCatalog = await SlotCatalog.load(concertSeries, year());
+			if (slotCatalog.slotCount === 0) {
+				return fail(400, { error: 'No schedule slots available.' });
 			}
+
+			const scheduleRepository = new ScheduleRepository();
+			const resolvedFormData = resolveScheduleFormData(formData, slotCatalog.slots);
+			const submission = ScheduleMapper.fromFormData(resolvedFormData, {
+				performerId: performerIdAsNumber,
+				concertSeries,
+				year: year(),
+				slots: slotCatalog.slots
+			});
+			const validation = ScheduleValidator.validate(submission, slotCatalog.slotCount);
+			if (!validation.valid) {
+				return fail(400, { error: validation.errors[0] });
+			}
+
+			await scheduleRepository.upsertChoices(submission);
+			throw redirect(303, '/');
 		} else {
 			// failed param test null or empty parameters
 			return fail(400, { error: 'performer id or concert series is required' });


### PR DESCRIPTION
### Motivation
- Centralize and sanitize performer lookup logic and status mapping so schedule server code no longer calls legacy lookup helpers directly.
- Move schedule orchestration into small server-side services to improve testability and decouple responsibilities.
- Drive server behavior by slot counts rather than by concert series name so modes are computed from `SlotCatalog.slotCount`.
- Prepare the ground for row-per-slot storage and consistent mapping/validation for both confirm-only and rank-choice flows.

### Description
- Add `src/lib/server/performerLookup.ts` implementing `PerformerLookup` to sanitize URL inputs and centralize `OK`/`NOTFOUND`/`ERROR` mapping, and add `src/lib/server/scheduleValidator.ts` implementing `ScheduleValidator` with confirm-only and rank-choice rules.
- Refactor `src/routes/schedule/+page.server.ts` to use `PerformerLookup`, `SlotCatalog`, `ScheduleRepository`, and `ScheduleMapper` in `load()` and to return a single consistent view payload including `viewModel`, `slotCount`, and `slots`.
- Replace series-name branching in the form `actions.add` with a slot-driven pipeline that normalizes legacy form fields, maps form data via `ScheduleMapper.fromFormData`, validates with `ScheduleValidator`, persists via `ScheduleRepository.upsertChoices`, and redirects on success.
- Preserve existing query params and legacy form handling by normalizing legacy fields into the new `scheduleFieldNames` shape before mapping and validation.

### Testing
- No automated tests were executed as part of this change.
- Existing automated tests (unit and Playwright tests under `src/test/`) remain and should be run to validate the new service-driven flow (for example via the project test runner).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954a33621d883269894e0245f78baf4)