### PR TITLE
Refactor schedule page to render from server-provided slot view model

### DIFF
--- a/src/routes/schedule/+page.svelte
+++ b/src/routes/schedule/+page.svelte
@@ -100,6 +100,18 @@
 			disableFormSubmit = !(confirmed || notAvailable);
 		}
 	}
+
+	function handleConfirmChange(slotId) {
+		if (confirmSelections[slotId]) {
+			notAvailableSelections = { ...notAvailableSelections, [slotId]: false };
+		}
+	}
+
+	function handleNotAvailableChange(slotId) {
+		if (notAvailableSelections[slotId]) {
+			confirmSelections = { ...confirmSelections, [slotId]: false };
+		}
+	}
 </script>
 
 <svelte:head>
@@ -141,6 +153,7 @@
 							class="concerto-confirm"
 							id="concert-confirm"
 							bind:checked={confirmSelections[data.viewModel.slots[0].slotId]}
+							on:change={() => handleConfirmChange(data.viewModel.slots[0].slotId)}
 						/>
 						<p class="concerto-confirm">Confirm Attendance</p>
 						<input
@@ -149,6 +162,7 @@
 							class="concerto-confirm"
 							id="concert-not-available"
 							bind:checked={notAvailableSelections[data.viewModel.slots[0].slotId]}
+							on:change={() => handleNotAvailableChange(data.viewModel.slots[0].slotId)}
 						/>
 						<p class="concerto-confirm">Not Available</p>
 						<br /><br />


### PR DESCRIPTION
### Motivation
- Implement the UI refactor so the schedule page renders entirely from the server-provided view model and removes hard-coded 4-slot assumptions.
- Drive confirm-only vs rank-choice rendering by slot count rather than series name and support up to 10 dynamic slots.
- Persist and honor per-slot “not available” state and allow partial rankings while keeping server-side validation authoritative.
- Provide a client-side experience that mirrors server rules for optional validation and better hydration of saved choices.

### Description
- Replace hard-coded rank UI with dynamic rendering from `data.viewModel` and iterate over `viewModel.slots` to generate inputs.
- Introduce slot-based form field naming (`slot-<id>-rank`, `slot-<id>-not-available`, `slot-<id>-confirm`) and bind input state with `rankSelections`, `notAvailableSelections`, and `confirmSelections`.
- Implement client-side validation that mirrors server rules (at least one rank 1, unique ranks, allow partial ranks, and per-slot not-available) and disable the submit button accordingly.
- Update confirm-only flow to use `viewModel.mode === 'confirm-only'`, render the single-slot confirm/not-available controls, and carry through duration/comment fields unchanged.

### Testing
- Started the dev server with `npm run dev` to exercise the updated page and attempted to load `/schedule`.
- Captured a Playwright screenshot of the schedule page which produced an artifact at `artifacts/schedule-page.png`.
- Server-side rendering attempted to initialize the DB cache and failed with `connect ECONNREFUSED 127.0.0.1:5432`, causing SSR evaluation errors.
- No automated unit tests were run as part of this change; visual/dev run produced a screenshot but SSR errors indicate the DB must be available for full end-to-end verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954a72af41083268a3bff8b0930b85d)