### PR TITLE
Stabilize rank selection typing

### DIFF
--- a/src/lib/types/schedule.ts
+++ b/src/lib/types/schedule.ts
@@ -34,7 +34,7 @@ export type ScheduleViewModel =
 				rank: number | null;
 				notAvailable: boolean;
 			}>;
-			rankOptions: number[];
+			rankOptions: string[];
 	  };
 
 export interface ScheduleSubmission {

--- a/src/routes/schedule/+page.svelte
+++ b/src/routes/schedule/+page.svelte
@@ -42,8 +42,10 @@
 
 	function selectedRanks() {
 		return Object.entries(rankSelections)
-			.filter(([slotId, rank]) => !notAvailableSelections[slotId] && rank.trim() !== '')
-			.map(([, rank]) => Number(rank))
+			.filter(([slotId]) => !notAvailableSelections[slotId])
+			.map(([, rank]) => String(rank ?? '').trim())
+			.filter((rank) => rank !== '')
+			.map((rank) => Number(rank))
 			.filter((rank) => Number.isInteger(rank));
 	}
 

--- a/src/test/lib/scheduleMapper.test.ts
+++ b/src/test/lib/scheduleMapper.test.ts
@@ -78,7 +78,7 @@ describe('ScheduleMapper', () => {
 
 		expect(viewModel.mode).toBe('rank-choice');
 		expect(viewModel.slotCount).toBe(2);
-		expect(viewModel.rankOptions).toEqual([1, 2]);
+		expect(viewModel.rankOptions).toEqual(['1', '2']);
 		expect(viewModel.slots).toEqual([
 			{ slotId: 1, displayTime: 'Slot 1', rank: 1, notAvailable: false },
 			{ slotId: 2, displayTime: 'Slot 2', rank: null, notAvailable: true }
@@ -91,7 +91,7 @@ describe('ScheduleMapper', () => {
 
 		expect(viewModel.mode).toBe('rank-choice');
 		expect(viewModel.slotCount).toBe(4);
-		expect(viewModel.rankOptions).toEqual([1, 2, 3, 4]);
+		expect(viewModel.rankOptions).toEqual(['1', '2', '3', '4']);
 		expect(viewModel.slots).toHaveLength(4);
 	});
 
@@ -101,7 +101,7 @@ describe('ScheduleMapper', () => {
 
 		expect(viewModel.mode).toBe('rank-choice');
 		expect(viewModel.slotCount).toBe(10);
-		expect(viewModel.rankOptions).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+		expect(viewModel.rankOptions).toEqual(['1', '2', '3', '4', '5', '6', '7', '8', '9', '10']);
 		expect(viewModel.slots).toHaveLength(10);
 	});
 


### PR DESCRIPTION
### Motivation
- Prevent a transient "duplicate rankings" client-side validation when `rankSelections` contains mixed types or is partially initialized.
- Ensure the UI `<option>` values and view-model `rankOptions` share a stable string type so SSR selection and client bindings align.
- Make unit expectations consistent with the view-model typing to avoid brittle tests.

### Description
- Coerce and trim rank values to strings in `selectedRanks()` in `src/routes/schedule/+page.svelte` before parsing to numbers. 
- Change `ScheduleViewModel.rankOptions` to `string[]` in `src/lib/types/schedule.ts` so option values are strings end-to-end. 
- Update tests in `src/test/lib/scheduleMapper.test.ts` to expect string rank options (`['1','2',...]`).

### Testing
- Updated unit tests in `src/test/lib/scheduleMapper.test.ts` to match the new `rankOptions` typing. 
- No automated test suite was executed during this rollout (no tests were run or reported as passing/failing).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954bf96f37c8326b8e031b0f9b2f608)