### PR TITLE
Expand schedule flow test coverage

### DIFF
--- a/src/test/api/schedule-page.test.ts
+++ b/src/test/api/schedule-page.test.ts
@@ -1,8 +1,10 @@
-import { describe, it, assert, expect } from 'vitest';
+import { afterAll, beforeAll, describe, it, assert, expect } from 'vitest';
 import { chromium } from 'playwright';
 import { Performance } from '$lib/server/import';
 import { type ImportPerformanceInterface, year, parseMusicalPiece } from '$lib/server/common';
-import { deleteDBSchedule, getDBSchedule, lookupByCode } from '$lib/server/db';
+import { lookupByCode, pool } from '$lib/server/db';
+import { ScheduleRepository } from '$lib/server/scheduleRepository';
+import { SlotCatalog } from '$lib/server/slotCatalog';
 
 const emmaCarterPerformance =
 	'{ "class_name": "QQ.9-10.XE", "performer": "Emma Carter", "age": 12, "lottery": 123, "email": "uFiqpdx@example.com","phone": "999-555-4444","accompanist": "Zhi, Zhou","instrument": "Cello","musical_piece": [ {"title": "Concerto in C minor 3rd movement", "contributors": [ { "name": "Johann Christian Bach", "yearsActive": "None" }  ]  },{ "title": "Scherzo no.2 in B Flat Minor, op.31", "contributors": [  { "name": "Frédéric Chopin", "yearsActive": "None" }  ] } ], "concert_series": "Eastside"}';
@@ -10,21 +12,114 @@ const emmaCarterPerformance =
 const organSonataPerformance =
 	'{ "class_name": "ORG.11-12.A", "performer": "Kai Organ", "age": 17, "lottery": 456, "email": "kai.organ@example.com","phone": "222-333-4444","accompanist": "Pat Riley","instrument": "Piano","musical_piece": [ {"title": "Organ Sonata No.6 in G major, BWV 530", "contributors": [ { "name": "Johann Sebastian Bach", "yearsActive": "1685-1750", "role": "Composer" }, { "name": "Béla Bartók", "yearsActive": "1881-1945", "role": "Arranger" } ] } ], "concert_series": "Concerto"}';
 
-async function importEmmaCarterPerformance() {
-	const imported: ImportPerformanceInterface = JSON.parse(emmaCarterPerformance);
+const twoSlotSeries = 'TwoSlotTest';
+const tenSlotSeries = 'TenSlotTest';
+
+const scheduleRepository = new ScheduleRepository();
+
+async function importPerformance(performanceJson: string) {
+	const imported: ImportPerformanceInterface = JSON.parse(performanceJson);
 	const singlePerformance: Performance = new Performance();
 	return singlePerformance.initialize(imported);
 }
 
-export async function importOrganSonataPerformance() {
-	const imported: ImportPerformanceInterface = JSON.parse(organSonataPerformance);
-	const singlePerformance: Performance = new Performance();
-	return singlePerformance.initialize(imported);
+function makePerformanceJson({
+	className,
+	performer,
+	age,
+	lottery,
+	concertSeries,
+	musicalPieceTitle
+}: {
+	className: string;
+	performer: string;
+	age: number;
+	lottery: number;
+	concertSeries: string;
+	musicalPieceTitle: string;
+}) {
+	return JSON.stringify({
+		class_name: className,
+		performer,
+		age,
+		lottery,
+		email: `${performer.toLowerCase().replaceAll(' ', '.')}@example.com`,
+		phone: '111-222-3333',
+		accompanist: 'Test Accompanist',
+		instrument: 'Piano',
+		musical_piece: [
+			{
+				title: musicalPieceTitle,
+				contributors: [{ name: 'Ludwig van Beethoven', yearsActive: '1770-1827' }]
+			}
+		],
+		concert_series: concertSeries
+	});
 }
+
+async function seedConcertTimes(series: string, seedYear: number, slotCount: number) {
+	const connection = await pool.connect();
+	try {
+		await connection.query(
+			'DELETE FROM concert_times WHERE concert_series = $1 AND year = $2',
+			[series, seedYear]
+		);
+
+		for (let index = 1; index <= slotCount; index += 1) {
+			const startTime = `05/${String(index).padStart(2, '0')}/${seedYear}T10:00:00`;
+			await connection.query(
+				`INSERT INTO concert_times (concert_series, year, concert_number_in_series, start_time)
+         VALUES ($1, $2, $3, $4)`,
+				[series, seedYear, index, startTime]
+			);
+		}
+	} finally {
+		connection.release();
+	}
+}
+
+async function cleanupConcertTimes(series: string, cleanupYear: number) {
+	const connection = await pool.connect();
+	try {
+		await connection.query(
+			'DELETE FROM concert_times WHERE concert_series = $1 AND year = $2',
+			[series, cleanupYear]
+		);
+	} finally {
+		connection.release();
+	}
+}
+
+async function deleteScheduleChoices(performerId: number, concertSeries: string, scheduleYear: number) {
+	const connection = await pool.connect();
+	try {
+		await connection.query(
+			`DELETE FROM schedule_slot_choice
+       WHERE performer_id = $1
+         AND concert_series = $2
+         AND year = $3`,
+			[performerId, concertSeries, scheduleYear]
+		);
+	} finally {
+		connection.release();
+	}
+}
+
+const scheduleYear = year();
+
+beforeAll(async () => {
+	await seedConcertTimes(twoSlotSeries, scheduleYear, 2);
+	await seedConcertTimes(tenSlotSeries, scheduleYear, 10);
+});
+
+afterAll(async () => {
+	await cleanupConcertTimes(twoSlotSeries, scheduleYear);
+	await cleanupConcertTimes(tenSlotSeries, scheduleYear);
+});
 
 describe('Valid Eastside page', () => {
 	it('should insert carter', async () => {
-		const importResults = await importEmmaCarterPerformance();
+		const importResults = await importPerformance(emmaCarterPerformance);
 		console.log(
 			`Success perfomerId ${importResults.performerId} performanceId ${importResults.performanceId}`
 		);
@@ -32,9 +127,11 @@ describe('Valid Eastside page', () => {
 	});
 
 	it('should display schedule page with ranked choices (playwright)', async () => {
-		const importEmmaCarterResults = await importEmmaCarterPerformance();
+		const importEmmaCarterResults = await importPerformance(emmaCarterPerformance);
 		const EmmaCarterRecord = JSON.parse(emmaCarterPerformance);
 		const EmmaCarterMusicPiece = parseMusicalPiece(EmmaCarterRecord.musical_piece[0].title);
+		const slotCatalog = await SlotCatalog.load(EmmaCarterRecord.concert_series, scheduleYear);
+		const [firstSlot, secondSlot, thirdSlot, fourthSlot] = slotCatalog.slots;
 
 		const browser = await chromium.launch({ headless: true });
 		const page = await browser.newPage();
@@ -46,10 +143,10 @@ describe('Valid Eastside page', () => {
 			await page.waitForSelector('form#ranked-choice-form');
 
 			const rankSelectIds = [
-				'#rank-sat-first',
-				'#rank-sat-second',
-				'#rank-sun-third',
-				'#rank-sun-fourth'
+				`#slot-${firstSlot.id}-rank`,
+				`#slot-${secondSlot.id}-rank`,
+				`#slot-${thirdSlot.id}-rank`,
+				`#slot-${fourthSlot.id}-rank`
 			];
 			for (const id of rankSelectIds) {
 				const tagName = await page.$eval(id, (element) => element.tagName.toLowerCase());
@@ -66,11 +163,10 @@ describe('Valid Eastside page', () => {
 			);
 			expect(commentTagName).toBe('input');
 
-			console.log('test phase 1');
-			await page.selectOption('#rank-sat-first', '1');
-			await page.selectOption('#rank-sat-second', '3');
-			await page.selectOption('#rank-sun-fourth', '2');
-			await page.check('#nonviable-sun-third');
+			await page.selectOption(`#slot-${firstSlot.id}-rank`, '1');
+			await page.selectOption(`#slot-${secondSlot.id}-rank`, '3');
+			await page.selectOption(`#slot-${fourthSlot.id}-rank`, '2');
+			await page.check(`#slot-${thirdSlot.id}-not-available`);
 			await page.selectOption('#duration', '3');
 			await page.fill('#comment', 'Thank you');
 
@@ -78,27 +174,26 @@ describe('Valid Eastside page', () => {
 				page.waitForURL('**', { waitUntil: 'networkidle' }),
 				page.click('form#ranked-choice-form button[type="submit"]')
 			]);
-			console.log('test phase 2');
 			const validateFormValues = async () => {
 				await page.waitForSelector('text=Lookup code 123');
 				const firstRankValue = await page.$eval(
-					'#rank-sat-first',
+					`#slot-${firstSlot.id}-rank`,
 					(element) => (element as HTMLSelectElement).value
 				);
 				const secondRankValue = await page.$eval(
-					'#rank-sat-second',
+					`#slot-${secondSlot.id}-rank`,
 					(element) => (element as HTMLSelectElement).value
 				);
 				const fourthRankValue = await page.$eval(
-					'#rank-sun-fourth',
+					`#slot-${fourthSlot.id}-rank`,
 					(element) => (element as HTMLSelectElement).value
 				);
 				const thirdNotAvailableChecked = await page.$eval(
-					'#nonviable-sun-third',
+					`#slot-${thirdSlot.id}-not-available`,
 					(element) => (element as HTMLInputElement).checked
 				);
 				const thirdRankDisabled = await page.$eval(
-					'#rank-sun-third',
+					`#slot-${thirdSlot.id}-rank`,
 					(element) => (element as HTMLSelectElement).disabled
 				);
 				const durationValue = await page.$eval(
@@ -109,7 +204,6 @@ describe('Valid Eastside page', () => {
 					'#comment',
 					(element) => (element as HTMLInputElement).value
 				);
-				console.log('test phase 3');
 				expect(firstRankValue).toBe('1');
 				expect(secondRankValue).toBe('3');
 				expect(fourthRankValue).toBe('2');
@@ -119,13 +213,11 @@ describe('Valid Eastside page', () => {
 				expect(commentValue).toBe('Thank you');
 			};
 
-			console.log('test phase 4');
 			await page.goto('http://localhost:8888/schedule?code=123');
 			await validateFormValues();
 
 			await page.reload({ waitUntil: 'networkidle' });
 			await validateFormValues();
-			console.log('test phase 5');
 			const performanceResults = await lookupByCode('123');
 			expect(performanceResults?.performance_duration).toBe(3);
 			expect(performanceResults?.performance_comment).toBe('Thank you');
@@ -133,29 +225,33 @@ describe('Valid Eastside page', () => {
 			expect(performanceResults?.musical_piece).toBe(EmmaCarterMusicPiece.titleWithoutMovement);
 			expect(performanceResults?.concert_series).toBe(EmmaCarterRecord.concert_series);
 
-			const performanceSchedule = await getDBSchedule(
+			const performanceSchedule = await scheduleRepository.fetchChoices(
 				importEmmaCarterResults.performerId,
 				EmmaCarterRecord.concert_series,
-				year()
+				scheduleYear
 			);
-			expect(performanceSchedule.rows[0].first_choice_time).toBeTruthy();
-			expect(performanceSchedule.rows[0].second_choice_time).toBeTruthy();
-			expect(performanceSchedule.rows[0].third_choice_time).toBeTruthy();
-			expect(performanceSchedule.rows[0].fourth_choice_time).not.toBeTruthy();
+			expect(performanceSchedule?.slots).toEqual([
+				{ slotId: firstSlot.id, rank: 1, notAvailable: false },
+				{ slotId: secondSlot.id, rank: 3, notAvailable: false },
+				{ slotId: thirdSlot.id, rank: null, notAvailable: true },
+				{ slotId: fourthSlot.id, rank: 2, notAvailable: false }
+			]);
 		} finally {
-			deleteDBSchedule(
+			await deleteScheduleChoices(
 				importEmmaCarterResults.performerId,
 				EmmaCarterRecord.concert_series,
-				year()
+				scheduleYear
 			);
 			await browser.close();
 		}
 	});
 
 	it('Valid Concerto page', async () => {
-		const OrganSonataResults = await importOrganSonataPerformance();
+		const OrganSonataResults = await importPerformance(organSonataPerformance);
 		const OrganSonataRecord = JSON.parse(organSonataPerformance);
 		const OrganSonataMusicPeice = parseMusicalPiece(OrganSonataRecord.musical_piece[0].title);
+		const slotCatalog = await SlotCatalog.load(OrganSonataRecord.concert_series, scheduleYear);
+		const [slot] = slotCatalog.slots;
 
 		const browser = await chromium.launch({ headless: true });
 		const page = await browser.newPage();
@@ -203,17 +299,185 @@ describe('Valid Eastside page', () => {
 			expect(performanceResults?.musical_piece).toBe(OrganSonataMusicPeice.titleWithoutMovement);
 			expect(performanceResults?.concert_series).toBe(OrganSonataRecord.concert_series);
 
-			const performanceSchedule = await getDBSchedule(
+			const performanceSchedule = await scheduleRepository.fetchChoices(
 				OrganSonataResults.performerId,
 				OrganSonataRecord.concert_series,
-				year()
+				scheduleYear
 			);
-			expect(performanceSchedule.rows[0].first_choice_time).toBeTruthy();
-			expect(performanceSchedule.rows[0].second_choice_time).not.toBeTruthy();
-			expect(performanceSchedule.rows[0].third_choice_time).not.toBeTruthy();
-			expect(performanceSchedule.rows[0].forth_choice_time).not.toBeTruthy();
+			expect(performanceSchedule?.slots).toEqual([
+				{ slotId: slot.id, rank: 1, notAvailable: false }
+			]);
 		} finally {
-			deleteDBSchedule(OrganSonataResults.performerId, OrganSonataRecord.concert_series, year());
+			await deleteScheduleChoices(
+				OrganSonataResults.performerId,
+				OrganSonataRecord.concert_series,
+				scheduleYear
+			);
+			await browser.close();
+		}
+	});
+});
+
+describe('Rank-choice variants', () => {
+	it('supports rank-choice with two slots and partial rankings', async () => {
+		const performanceJson = makePerformanceJson({
+			className: 'TS.2.A',
+			performer: 'Duo Player',
+			age: 11,
+			lottery: 2345,
+			concertSeries: twoSlotSeries,
+			musicalPieceTitle: 'Test Sonata in C'
+		});
+		const importResults = await importPerformance(performanceJson);
+		const slotCatalog = await SlotCatalog.load(twoSlotSeries, scheduleYear);
+		const [firstSlot, secondSlot] = slotCatalog.slots;
+
+		const browser = await chromium.launch({ headless: true });
+		const page = await browser.newPage();
+		try {
+			await page.goto('http://localhost:8888/schedule?code=2345');
+			const rankSelects = page.locator('select[id$="-rank"]');
+			const rankSelectCount = await rankSelects.count();
+			expect(rankSelectCount).toBe(2);
+
+			await page.selectOption(`#slot-${firstSlot.id}-rank`, '1');
+			await Promise.all([
+				page.waitForURL('**', { waitUntil: 'networkidle' }),
+				page.click('form#ranked-choice-form button[type="submit"]')
+			]);
+
+			await page.goto('http://localhost:8888/schedule?code=2345');
+			const firstRankValue = await page.$eval(
+				`#slot-${firstSlot.id}-rank`,
+				(element) => (element as HTMLSelectElement).value
+			);
+			const secondRankValue = await page.$eval(
+				`#slot-${secondSlot.id}-rank`,
+				(element) => (element as HTMLSelectElement).value
+			);
+			expect(firstRankValue).toBe('1');
+			expect(secondRankValue).toBe('');
+
+			const stored = await scheduleRepository.fetchChoices(
+				importResults.performerId,
+				twoSlotSeries,
+				scheduleYear
+			);
+			expect(stored?.slots).toEqual([
+				{ slotId: firstSlot.id, rank: 1, notAvailable: false },
+				{ slotId: secondSlot.id, rank: null, notAvailable: false }
+			]);
+		} finally {
+			await deleteScheduleChoices(importResults.performerId, twoSlotSeries, scheduleYear);
+			await browser.close();
+		}
+	});
+
+	it('supports rank-choice with ten slots', async () => {
+		const performanceJson = makePerformanceJson({
+			className: 'TS.10.A',
+			performer: 'Ten Slot Performer',
+			age: 12,
+			lottery: 3456,
+			concertSeries: tenSlotSeries,
+			musicalPieceTitle: 'Test Suite in D'
+		});
+		const importResults = await importPerformance(performanceJson);
+
+		const browser = await chromium.launch({ headless: true });
+		const page = await browser.newPage();
+		try {
+			await page.goto('http://localhost:8888/schedule?code=3456');
+			const rankSelects = page.locator('select[id$="-rank"]');
+			const rankSelectCount = await rankSelects.count();
+			expect(rankSelectCount).toBe(10);
+			const optionCount = await rankSelects
+				.first()
+				.locator('option')
+				.count();
+			expect(optionCount).toBe(11);
+		} finally {
+			await deleteScheduleChoices(importResults.performerId, tenSlotSeries, scheduleYear);
+			await browser.close();
+		}
+	});
+
+	it('rejects duplicate rankings', async () => {
+		const performanceJson = makePerformanceJson({
+			className: 'TS.2.B',
+			performer: 'Duplicate Rank',
+			age: 13,
+			lottery: 3457,
+			concertSeries: twoSlotSeries,
+			musicalPieceTitle: 'Duplicate Sonata'
+		});
+		const importResults = await importPerformance(performanceJson);
+		const slotCatalog = await SlotCatalog.load(twoSlotSeries, scheduleYear);
+		const [firstSlot, secondSlot] = slotCatalog.slots;
+
+		const browser = await chromium.launch({ headless: true });
+		const page = await browser.newPage();
+		try {
+			await page.goto('http://localhost:8888/schedule?code=3457');
+			await page.selectOption(`#slot-${firstSlot.id}-rank`, '1');
+			await page.selectOption(`#slot-${secondSlot.id}-rank`, '1');
+
+			const [response] = await Promise.all([
+				page.waitForResponse(
+					(resp) => resp.url().includes('/schedule?/add') && resp.request().method() === 'POST'
+				),
+				page.$eval('form#ranked-choice-form', (form: HTMLFormElement) => form.submit())
+			]);
+			expect(response.status()).toBe(400);
+
+			const stored = await scheduleRepository.fetchChoices(
+				importResults.performerId,
+				twoSlotSeries,
+				scheduleYear
+			);
+			expect(stored).toBeNull();
+		} finally {
+			await deleteScheduleChoices(importResults.performerId, twoSlotSeries, scheduleYear);
+			await browser.close();
+		}
+	});
+
+	it('rejects submissions missing rank 1', async () => {
+		const performanceJson = makePerformanceJson({
+			className: 'TS.2.C',
+			performer: 'Missing Rank',
+			age: 13,
+			lottery: 3458,
+			concertSeries: twoSlotSeries,
+			musicalPieceTitle: 'Missing Rank Sonata'
+		});
+		const importResults = await importPerformance(performanceJson);
+		const slotCatalog = await SlotCatalog.load(twoSlotSeries, scheduleYear);
+		const [firstSlot, secondSlot] = slotCatalog.slots;
+
+		const browser = await chromium.launch({ headless: true });
+		const page = await browser.newPage();
+		try {
+			await page.goto('http://localhost:8888/schedule?code=3458');
+			await page.selectOption(`#slot-${firstSlot.id}-rank`, '2');
+			await page.selectOption(`#slot-${secondSlot.id}-rank`, '');
+
+			const [response] = await Promise.all([
+				page.waitForResponse(
+					(resp) => resp.url().includes('/schedule?/add') && resp.request().method() === 'POST'
+				),
+				page.$eval('form#ranked-choice-form', (form: HTMLFormElement) => form.submit())
+			]);
+			expect(response.status()).toBe(400);
+
+			const stored = await scheduleRepository.fetchChoices(
+				importResults.performerId,
+				twoSlotSeries,
+				scheduleYear
+			);
+			expect(stored).toBeNull();
+		} finally {
+			await deleteScheduleChoices(importResults.performerId, twoSlotSeries, scheduleYear);
 			await browser.close();
 		}
 	});

--- a/src/test/lib/scheduleValidator.test.ts
+++ b/src/test/lib/scheduleValidator.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import { ScheduleValidator } from '$lib/server/scheduleValidator';
+import type { ScheduleSubmission } from '$lib/types/schedule';
+
+const baseSubmission: ScheduleSubmission = {
+	performerId: 101,
+	concertSeries: 'TestSeries',
+	year: 2030,
+	slots: []
+};
+
+describe('ScheduleValidator', () => {
+	it('accepts confirm-only submissions when confirmed', () => {
+		const submission: ScheduleSubmission = {
+			...baseSubmission,
+			slots: [{ slotId: 1, rank: 1, notAvailable: false }]
+		};
+
+		const result = ScheduleValidator.validate(submission, 1);
+
+		expect(result.valid).toBe(true);
+	});
+
+	it('accepts confirm-only submissions when marked not available', () => {
+		const submission: ScheduleSubmission = {
+			...baseSubmission,
+			slots: [{ slotId: 1, rank: null, notAvailable: true }]
+		};
+
+		const result = ScheduleValidator.validate(submission, 1);
+
+		expect(result.valid).toBe(true);
+	});
+
+	it('rejects confirm-only submissions without a selection', () => {
+		const submission: ScheduleSubmission = {
+			...baseSubmission,
+			slots: [{ slotId: 1, rank: null, notAvailable: false }]
+		};
+
+		const result = ScheduleValidator.validate(submission, 1);
+
+		expect(result.valid).toBe(false);
+		expect(result.errors).toContain('Confirmation selection is required.');
+	});
+
+	it('accepts partial rankings when rank 1 is present', () => {
+		const submission: ScheduleSubmission = {
+			...baseSubmission,
+			slots: [
+				{ slotId: 1, rank: 1, notAvailable: false },
+				{ slotId: 2, rank: null, notAvailable: false },
+				{ slotId: 3, rank: 2, notAvailable: false }
+			]
+		};
+
+		const result = ScheduleValidator.validate(submission, 3);
+
+		expect(result.valid).toBe(true);
+	});
+
+	it('rejects duplicate rankings', () => {
+		const submission: ScheduleSubmission = {
+			...baseSubmission,
+			slots: [
+				{ slotId: 1, rank: 1, notAvailable: false },
+				{ slotId: 2, rank: 1, notAvailable: false }
+			]
+		};
+
+		const result = ScheduleValidator.validate(submission, 2);
+
+		expect(result.valid).toBe(false);
+		expect(result.errors).toContain('Duplicate rankings selected.');
+	});
+
+	it('rejects submissions missing a first-choice rank', () => {
+		const submission: ScheduleSubmission = {
+			...baseSubmission,
+			slots: [
+				{ slotId: 1, rank: 2, notAvailable: false },
+				{ slotId: 2, rank: null, notAvailable: false }
+			]
+		};
+
+		const result = ScheduleValidator.validate(submission, 2);
+
+		expect(result.valid).toBe(false);
+		expect(result.errors).toContain('At least one slot must be ranked as first choice.');
+	});
+
+	it('rejects not-available entries that include a rank', () => {
+		const submission: ScheduleSubmission = {
+			...baseSubmission,
+			slots: [
+				{ slotId: 1, rank: 1, notAvailable: false },
+				{ slotId: 2, rank: 2, notAvailable: true }
+			]
+		};
+
+		const result = ScheduleValidator.validate(submission, 2);
+
+		expect(result.valid).toBe(false);
+		expect(result.errors).toContain('Not-available selections cannot include a rank.');
+	});
+});


### PR DESCRIPTION
### Motivation

- Implement Phase 5 Deliverable 10 test coverage from the schedule refactor spec to validate the refactored slot-based flow.
- Increase regression safety by exercising server-side validation, mapping and repository persistence with automated tests.
- Cover both page-level flows (`confirm-only` and `rank-choice`) and unit-level behaviors for core classes.
- Ensure edge cases (partial rankings, duplicate ranks, missing rank 1, and not-available persistence) are validated.

### Description

- Added unit tests for `ScheduleValidator` in `src/test/lib/scheduleValidator.test.ts` that exercise confirm-only and rank-choice rules and edge cases.
- Rewrote and expanded the Playwright page-level tests in `src/test/api/schedule-page.test.ts` to use slot-based field names and `SlotCatalog`, seed `concert_times`, and assert persistence via `ScheduleRepository.fetchChoices`.
- Introduced helper test routines for seeding/cleaning `concert_times` and deleting `schedule_slot_choice` rows used by the page tests.
- Committed the updated test files and adjusted assertions to match the new row-per-slot schedule storage and mapping logic.

### Testing

- Added `src/test/lib/scheduleValidator.test.ts` (unit tests for `ScheduleValidator`) but these tests were not executed in this rollout.
- Updated `src/test/api/schedule-page.test.ts` (Playwright page-level tests covering single-slot confirm-only, rank-choice with 2/4/10 slots, partial rankings, duplicate/missing rank validation, and not-available persistence) but they were not executed in this rollout.
- No automated test runner (`vitest`/Playwright) was run as part of this PR, so no pass/fail results are available here.
- Recommend running `npm test` (or `vitest`) and the Playwright suite in CI before merge to verify all added tests pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69553c6d51888326a10b008e6d77bb6c)