### PR TITLE
Resolve ranked slot IDs to concert numbers in program build

### DIFF
--- a/src/lib/server/db.ts
+++ b/src/lib/server/db.ts
@@ -1101,8 +1101,8 @@ export async function retrievePerformanceByLottery(year: number) {
 			'performance.concert_series, performance.year, performance.chair_override, \n' +
 			'class_lottery.lottery as lookup_code, \n' +
 			'class_lottery.lottery, \n' +
-			'ARRAY_AGG(concert_times.concert_number_in_series ORDER BY schedule_slot_choice.rank) \n' +
-			'    FILTER (WHERE schedule_slot_choice.rank IS NOT NULL AND schedule_slot_choice.not_available = false) as ranked_slots \n' +
+			'ARRAY_AGG(concert_times.id ORDER BY schedule_slot_choice.rank) \n' +
+			'    FILTER (WHERE schedule_slot_choice.rank IS NOT NULL AND schedule_slot_choice.not_available = false) as ranked_slot_ids \n' +
 			'FROM performance \n' +
 			'JOIN class_lottery ON class_lottery.class_name = performance.class_name \n' +
 			'LEFT JOIN schedule_slot_choice \n' +


### PR DESCRIPTION
### Motivation

- Remove reliance on fragile “magic integers” by using schedule slot IDs that directly reference `concert_times.id`.
- Ensure ranked choices are traceable to `schedule_slot_choice` rows and `concert_times` records for multi-series and future expansions.
- Align program generation logic with the canonical schedule slot representation to reduce ambiguity.

### Description

- Change `retrievePerformanceByLottery` SQL to aggregate `concert_times.id` as `ranked_slot_ids` instead of `concert_number_in_series` in `src/lib/server/db.ts`.
- Update `Program.build()` in `src/lib/server/program.ts` to load `SlotCatalog` and build a `slotId -> concertNumberInSeries` map per concert series.
- Add `normalizeRankedSlotIds` and `mapSlotIdsToConcertNumbers` helpers and convert raw `ranked_slot_ids` into `rankedChoiceConcerts` used by the allocation logic.
- Preserve existing placement and ordering logic while ensuring choices are resolved from slot IDs to concert numbers before allocation.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695720cc35888326a8131d1c24c02187)