### PR TITLE
Refactor Musical Piece Tags

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,4 @@ package-lock.json
 pnpm-lock.yaml
 yarn.lock
 static/docs
+tasks

--- a/docs/musical-piece-api.yaml
+++ b/docs/musical-piece-api.yaml
@@ -5,7 +5,7 @@ info:
     CRUD endpoints for musical pieces used by the Concert Program app. External clients must provide
     an Authorization bearer token; first-party calls from the same origin may instead use the
     `pafe_auth` cookie issued by the service.
-  version: 0.5.0
+  version: 0.6.0
 servers:
   - url: 'https://schedule.pafenorthwest.org/api/'
 
@@ -15,8 +15,10 @@ paths:
       summary: create a new musical piece
       description: >
         Adds a musical piece. Requires `printed_name` and `first_contributor_id`; other fields are
-        optional. External clients must send an Authorization bearer token while same-origin calls
-        may rely on the `pafe_auth` cookie.
+        optional. Optional `division_tags` and `category_tags` are validated against enums. If
+        `category_tags` includes `Not Appropriate`, no other categories are permitted. External
+        clients must send an Authorization bearer token while same-origin calls may rely on the
+        `pafe_auth` cookie.
       security:
         - PafeAuthCookie: []
         - BearerAuth: []
@@ -37,6 +39,10 @@ paths:
               flag_for_discussion: false
               discussion_notes: null
               is_not_appropriate: false
+              division_tags:
+                - Piano
+              category_tags:
+                - Solo
       responses:
         201:
           description: created
@@ -48,7 +54,7 @@ paths:
                 id: 42
                 message: 'Update successful'
         400:
-          description: missing required fields
+          description: missing required fields or invalid tag values
           content:
             application/json:
               schema:
@@ -117,7 +123,10 @@ paths:
       description: >
         Updates musical piece fields. External requests require an Authorization bearer token; calls
         from the same origin as the app may omit the header and use the `pafe_auth` cookie instead.
-        `printed_name` and `first_contributor_id` are required.
+        `printed_name` and `first_contributor_id` are required. Optional `division_tags` and
+        `category_tags` replace existing tags when provided (non-empty arrays). Optional
+        `rm_division_tags` and `rm_category_tags` remove tags (non-empty arrays) and cannot be used
+        with add tags in the same request. `rm_category_tags` cannot include `Not Appropriate`.
       security:
         - PafeAuthCookie: []
         - BearerAuth: []
@@ -138,6 +147,10 @@ paths:
               flag_for_discussion: true
               discussion_notes: 'Check edition with orchestra reduction'
               is_not_appropriate: false
+              division_tags:
+                - Piano
+              category_tags:
+                - Solo
       responses:
         200:
           description: updated
@@ -302,11 +315,20 @@ components:
         is_not_appropriate:
           type: boolean
           default: false
+        division_tags:
+          $ref: '#/components/schemas/DivisionTagList'
+        category_tags:
+          $ref: '#/components/schemas/PieceCategoryList'
 
     MusicalPieceUpdateRequest:
       allOf:
         - $ref: '#/components/schemas/MusicalPieceCreateRequest'
       description: Fields accepted by the update endpoint.
+      properties:
+        rm_division_tags:
+          $ref: '#/components/schemas/DivisionTagList'
+        rm_category_tags:
+          $ref: '#/components/schemas/PieceCategoryList'
 
     EntityCreated:
       type: object
@@ -351,3 +373,29 @@ components:
         message:
           type: string
           nullable: true
+
+    DivisionTagList:
+      type: array
+      items:
+        $ref: '#/components/schemas/DivisionTag'
+
+    PieceCategoryList:
+      type: array
+      items:
+        $ref: '#/components/schemas/PieceCategory'
+
+    DivisionTag:
+      type: string
+      enum:
+        - Violin Viola
+        - Cello Bass
+        - Piano
+        - Woodwinds
+
+    PieceCategory:
+      type: string
+      enum:
+        - Concerto
+        - Solo
+        - Ensemble
+        - Not Appropriate

--- a/src/lib/server/review.ts
+++ b/src/lib/server/review.ts
@@ -34,6 +34,34 @@ export function isValidPieceCategory(value: unknown): value is PieceCategory {
 	return typeof value === 'string' && pieceCategories.includes(value as PieceCategory);
 }
 
+function normalizeTagStrings(values: string[]): string[] {
+	return values.map((value) => value.trim()).filter((value) => value.length > 0);
+}
+
+function dedupeStrings(values: string[]): string[] {
+	return Array.from(new Set(values));
+}
+
+export function parseDivisionTags(input: unknown): {
+	tags: DivisionTag[];
+	invalid: string[];
+} {
+	const values = dedupeStrings(normalizeTagStrings(asStringArray(input)));
+	const tags = values.filter(isValidDivisionTag);
+	const invalid = values.filter((value) => !isValidDivisionTag(value));
+	return { tags, invalid };
+}
+
+export function parsePieceCategories(input: unknown): {
+	tags: PieceCategory[];
+	invalid: string[];
+} {
+	const values = dedupeStrings(normalizeTagStrings(asStringArray(input)));
+	const tags = values.filter(isValidPieceCategory);
+	const invalid = values.filter((value) => !isValidPieceCategory(value));
+	return { tags, invalid };
+}
+
 export function normalizePieceCategories(categories: PieceCategory[]): PieceCategory[] {
 	if (categories.includes('Not Appropriate')) {
 		return ['Not Appropriate'];
@@ -264,6 +292,44 @@ export async function setPieceDivisionTags(
 	} catch (error) {
 		await client.query('ROLLBACK');
 		throw error;
+	} finally {
+		client.release();
+	}
+}
+
+export async function removePieceCategories(
+	musicalPieceId: number,
+	categories: PieceCategory[]
+): Promise<number> {
+	if (categories.length === 0) {
+		return 0;
+	}
+	const client = await pool.connect();
+	try {
+		const result = await client.query(
+			`DELETE FROM musical_piece_category_map WHERE musical_piece_id = $1 AND category = ANY($2)`,
+			[musicalPieceId, categories]
+		);
+		return result.rowCount ?? 0;
+	} finally {
+		client.release();
+	}
+}
+
+export async function removePieceDivisionTags(
+	musicalPieceId: number,
+	tags: DivisionTag[]
+): Promise<number> {
+	if (tags.length === 0) {
+		return 0;
+	}
+	const client = await pool.connect();
+	try {
+		const result = await client.query(
+			`DELETE FROM musical_piece_division_tag WHERE musical_piece_id = $1 AND division_tag = ANY($2)`,
+			[musicalPieceId, tags]
+		);
+		return result.rowCount ?? 0;
 	} finally {
 		client.release();
 	}

--- a/src/routes/admin/musicalpiece/+page.server.ts
+++ b/src/routes/admin/musicalpiece/+page.server.ts
@@ -1,16 +1,72 @@
-import { queryTable, deleteById, insertTable } from '$lib/server/db';
+import { pool, queryTable, deleteById, insertTable } from '$lib/server/db';
 import { type MusicalPieceInterface, formatFieldNames } from '$lib/server/common.ts';
+import { divisionTags, pieceCategories } from '$lib/constants/review';
+import {
+	isValidDivisionTag,
+	isValidPieceCategory,
+	setPieceCategories,
+	setPieceDivisionTags
+} from '$lib/server/review';
 
 export async function load({ cookies }) {
 	const pafeAuth = cookies.get('pafe_auth');
 	const isAuthenticated = !!pafeAuth;
+	const toTagArray = (value: unknown): string[] => {
+		if (Array.isArray(value)) {
+			return value.filter((item): item is string => typeof item === 'string');
+		}
+		if (typeof value === 'string') {
+			try {
+				const parsed = JSON.parse(value);
+				return Array.isArray(parsed)
+					? parsed.filter((item): item is string => typeof item === 'string')
+					: [];
+			} catch {
+				return [];
+			}
+		}
+		return [];
+	};
 
 	const res = await queryTable('musical_piece');
+	const categoryResult = await pool.query<{
+		musical_piece_id: number;
+		tags: unknown;
+	}>(`SELECT musical_piece_id, jsonb_agg(DISTINCT category) AS tags
+		FROM musical_piece_category_map
+		GROUP BY musical_piece_id`);
+	const divisionResult = await pool.query<{
+		musical_piece_id: number;
+		tags: unknown;
+	}>(`SELECT musical_piece_id, jsonb_agg(DISTINCT division_tag) AS tags
+		FROM musical_piece_division_tag
+		GROUP BY musical_piece_id`);
+	const categoriesByPiece = new Map<number, string[]>();
+	for (const row of categoryResult.rows) {
+		categoriesByPiece.set(row.musical_piece_id, toTagArray(row.tags));
+	}
+	const divisionsByPiece = new Map<number, string[]>();
+	for (const row of divisionResult.rows) {
+		divisionsByPiece.set(row.musical_piece_id, toTagArray(row.tags));
+	}
+	const musicalPieces = res.rows.map((piece) => {
+		const categoryTags = (categoriesByPiece.get(piece.id) ?? []).slice().sort();
+		const divisionTagValues = (divisionsByPiece.get(piece.id) ?? []).slice().sort();
+		return {
+			...piece,
+			category_tags: categoryTags,
+			division_tags: divisionTagValues,
+			category_tag: categoryTags[0] ?? null,
+			division_tag: divisionTagValues[0] ?? null
+		};
+	});
 	const columnNames: string[] = res.fields.map((record) => formatFieldNames(record.name));
 	return {
-		musicalPieces: res.rows,
+		musicalPieces,
 		musical_piece_fields: columnNames,
-		isAuthenticated: isAuthenticated
+		isAuthenticated: isAuthenticated,
+		categoryOptions: pieceCategories,
+		divisionOptions: divisionTags
 	};
 }
 
@@ -52,6 +108,8 @@ export const actions = {
 			discussion_notes: toNullableString(formData.get('discussionNotes')),
 			is_not_appropriate: formData.get('isNotAppropriate') === 'on'
 		};
+		const rawCategoryTag = toNullableString(formData.get('categoryTag'));
+		const rawDivisionTag = toNullableString(formData.get('divisionTag'));
 
 		if (
 			!musicalPiece.printed_name ||
@@ -59,9 +117,22 @@ export const actions = {
 			musicalPiece.first_contributor_id == null
 		) {
 			return { status: 400, body: { message: 'Missing Field, Try Again' } };
+		}
+		if (rawCategoryTag && !isValidPieceCategory(rawCategoryTag)) {
+			return { status: 400, body: { message: 'Invalid category tag' } };
+		}
+		if (rawDivisionTag && !isValidDivisionTag(rawDivisionTag)) {
+			return { status: 400, body: { message: 'Invalid division tag' } };
 		} else {
 			const result = await insertTable('musical_piece', musicalPiece);
 			if (result.rowCount != null && result.rowCount > 0) {
+				const newId = result.rows[0].id as number;
+				if (rawCategoryTag) {
+					await setPieceCategories(newId, [rawCategoryTag]);
+				}
+				if (rawDivisionTag) {
+					await setPieceDivisionTags(newId, [rawDivisionTag]);
+				}
 				return { status: 200, body: { message: 'Insert successful' } };
 			} else {
 				return { status: 500, body: { message: 'Insert failed' } };

--- a/src/routes/admin/musicalpiece/+page.svelte
+++ b/src/routes/admin/musicalpiece/+page.svelte
@@ -19,6 +19,8 @@
 
 	async function handleSave(musicalPiece) {
 		try {
+			const categoryTag = normalizeText(musicalPiece.category_tag);
+			const divisionTag = normalizeText(musicalPiece.division_tag);
 			const payload = {
 				...musicalPiece,
 				first_contributor_id: Number(musicalPiece.first_contributor_id),
@@ -29,7 +31,9 @@
 				comments: normalizeText(musicalPiece.comments),
 				flag_for_discussion: !!musicalPiece.flag_for_discussion,
 				discussion_notes: normalizeText(musicalPiece.discussion_notes),
-				is_not_appropriate: !!musicalPiece.is_not_appropriate
+				is_not_appropriate: !!musicalPiece.is_not_appropriate,
+				category_tags: categoryTag ? [categoryTag] : undefined,
+				division_tags: divisionTag ? [divisionTag] : undefined
 			};
 			const response = await fetch(`/api/musicalpiece/${musicalPiece.id}`, {
 				method: 'PUT',
@@ -101,6 +105,20 @@
 				<label class="checkbox-label" for="isNotAppropriate">
 					<input type="checkbox" id="isNotAppropriate" name="isNotAppropriate" /> Not Appropriate
 				</label>
+				<label for="categoryTag">Category Tag:</label>
+				<select id="categoryTag" name="categoryTag">
+					<option value="">Select a category</option>
+					{#each data.categoryOptions as category}
+						<option value={category}>{category}</option>
+					{/each}
+				</select>
+				<label for="divisionTag">Division Tag:</label>
+				<select id="divisionTag" name="divisionTag">
+					<option value="">Select a division</option>
+					{#each data.divisionOptions as division}
+						<option value={division}>{division}</option>
+					{/each}
+				</select>
 			</div>
 			<div class="form-group">
 				<button type="submit" disabled={disableStatus}>Submit</button>
@@ -108,12 +126,18 @@
 		</form>
 	</div>
 	<h3>Listing</h3>
+	<p class="note">
+		Multi-tag updates are supported in the API only. Saving from this UI will overwrite tags with
+		the single selection shown here.
+	</p>
 	<table class="table">
 		<thead>
 			<tr>
 				{#each data.musical_piece_fields as field}
 					<th>{field}</th>
 				{/each}
+				<th>Category Tag</th>
+				<th>Division Tag</th>
 				<th>Edit</th>
 				<th>Delete</th>
 			</tr>
@@ -232,6 +256,36 @@
 					</td>
 					<td>
 						{musicalPiece.updated_at ? new Date(musicalPiece.updated_at).toLocaleString() : ''}
+					</td>
+					<td>
+						{#if editing.id === musicalPiece.id}
+							<select
+								value={editing.category_tag ?? ''}
+								on:change={(event) => handleInputChange(event, 'category_tag')}
+							>
+								<option value="">Select a category</option>
+								{#each data.categoryOptions as category}
+									<option value={category}>{category}</option>
+								{/each}
+							</select>
+						{:else}
+							{musicalPiece.category_tag ?? ''}
+						{/if}
+					</td>
+					<td>
+						{#if editing.id === musicalPiece.id}
+							<select
+								value={editing.division_tag ?? ''}
+								on:change={(event) => handleInputChange(event, 'division_tag')}
+							>
+								<option value="">Select a division</option>
+								{#each data.divisionOptions as division}
+									<option value={division}>{division}</option>
+								{/each}
+							</select>
+						{:else}
+							{musicalPiece.division_tag ?? ''}
+						{/if}
 					</td>
 					<td>
 						{#if editing.id === musicalPiece.id}

--- a/src/routes/api/musicalpiece/[id]/+server.ts
+++ b/src/routes/api/musicalpiece/[id]/+server.ts
@@ -2,6 +2,14 @@ import { type MusicalPieceInterface } from '$lib/server/common';
 import { deleteById, queryTable, updateById } from '$lib/server/db';
 import { json } from '@sveltejs/kit';
 import { isAuthorizedRequest } from '$lib/server/apiAuth';
+import {
+	parseDivisionTags,
+	parsePieceCategories,
+	removePieceCategories,
+	removePieceDivisionTags,
+	setPieceCategories,
+	setPieceDivisionTags
+} from '$lib/server/review';
 
 export async function GET({ params }) {
 	try {
@@ -17,7 +25,8 @@ export async function GET({ params }) {
 export async function PUT({ url, params, request, cookies }) {
 	// Check Authorization
 	const pafeAuth = cookies.get('pafe_auth');
-	const origin = request.headers.get('origin'); // The origin of the request (protocol + host + port)
+	// The origin of the request (protocol + host + port)
+	const origin = request.headers.get('origin');
 	const appOrigin = `${url.protocol}//${url.host}`;
 
 	// from local app no checks needed
@@ -29,6 +38,15 @@ export async function PUT({ url, params, request, cookies }) {
 
 	try {
 		const body = await request.json();
+		const hasAddTags = body.division_tags !== undefined || body.category_tags !== undefined;
+		const hasRemoveCategory = body.rm_category_tags !== undefined;
+		const hasRemoveDivision = body.rm_division_tags !== undefined;
+		if ((hasRemoveCategory || hasRemoveDivision) && hasAddTags) {
+			return json(
+				{ status: 'error', reason: 'Removal tags cannot be combined with add tags' },
+				{ status: 400 }
+			);
+		}
 		const toNullableString = (value: unknown) => {
 			if (value === null || value === undefined) return null;
 			const trimmed = String(value).trim();
@@ -43,6 +61,22 @@ export async function PUT({ url, params, request, cookies }) {
 			value === true || value === 'true' || value === '1' || value === 1 || value === 'on';
 		const firstContributorId = Number(body.first_contributor_id);
 		const id = Number(params.id);
+		const { tags: divisionTags, invalid: divisionInvalid } = parseDivisionTags(body.division_tags);
+		const { tags: categoryTags, invalid: categoryInvalid } = parsePieceCategories(
+			body.category_tags
+		);
+		const { tags: rmDivisionTags, invalid: rmDivisionInvalid } = parseDivisionTags(
+			body.rm_division_tags
+		);
+		const { tags: rmCategoryTags, invalid: rmCategoryInvalid } = parsePieceCategories(
+			body.rm_category_tags
+		);
+		const shouldApplyDivisionTags = body.division_tags !== undefined && divisionTags.length > 0;
+		const shouldApplyCategoryTags = body.category_tags !== undefined && categoryTags.length > 0;
+		const shouldRemoveDivisionTags =
+			body.rm_division_tags !== undefined && rmDivisionTags.length > 0;
+		const shouldRemoveCategoryTags =
+			body.rm_category_tags !== undefined && rmCategoryTags.length > 0;
 		const musicalPiece: MusicalPieceInterface = {
 			id: Number.isNaN(id) ? null : id,
 			printed_name: body.printed_name,
@@ -56,11 +90,43 @@ export async function PUT({ url, params, request, cookies }) {
 			discussion_notes: toNullableString(body.discussion_notes),
 			is_not_appropriate: toBoolean(body.is_not_appropriate)
 		};
+		if (
+			divisionInvalid.length > 0 ||
+			categoryInvalid.length > 0 ||
+			rmDivisionInvalid.length > 0 ||
+			rmCategoryInvalid.length > 0
+		) {
+			return json({ status: 'error', reason: 'Invalid tag values' }, { status: 400 });
+		}
+		if (categoryTags.includes('Not Appropriate') && categoryTags.length > 1) {
+			return json(
+				{ status: 'error', reason: 'Not Appropriate cannot be combined with other categories' },
+				{ status: 400 }
+			);
+		}
+		if (rmCategoryTags.includes('Not Appropriate')) {
+			return json(
+				{ status: 'error', reason: 'Not Appropriate cannot be removed' },
+				{ status: 400 }
+			);
+		}
 		if (!musicalPiece.printed_name || Number.isNaN(firstContributorId) || musicalPiece.id == null) {
 			return { status: 400, body: { message: 'Missing Field, Try Again' } };
 		} else {
 			const rowCount = await updateById('musical_piece', musicalPiece);
 			if (rowCount != null && rowCount > 0) {
+				if (shouldApplyDivisionTags) {
+					await setPieceDivisionTags(musicalPiece.id, divisionTags);
+				}
+				if (shouldApplyCategoryTags) {
+					await setPieceCategories(musicalPiece.id, categoryTags);
+				}
+				if (shouldRemoveDivisionTags) {
+					await removePieceDivisionTags(musicalPiece.id, rmDivisionTags);
+				}
+				if (shouldRemoveCategoryTags) {
+					await removePieceCategories(musicalPiece.id, rmCategoryTags);
+				}
 				return json({ id: params.id }, { status: 200, body: { message: 'Update successful' } });
 			} else {
 				return json({ status: 'error', reason: 'Missing Fields', id: params.id }, { status: 500 });
@@ -74,7 +140,8 @@ export async function PUT({ url, params, request, cookies }) {
 export async function DELETE({ url, params, request, cookies }) {
 	// Get the Authorization header
 	const pafeAuth = cookies.get('pafe_auth');
-	const origin = request.headers.get('origin'); // The origin of the request (protocol + host + port)
+	// The origin of the request (protocol + host + port)
+	const origin = request.headers.get('origin');
 	const appOrigin = `${url.protocol}//${url.host}`;
 
 	// from local app no checks needed

--- a/src/test/api/musicalpiece-api.test.ts
+++ b/src/test/api/musicalpiece-api.test.ts
@@ -1,12 +1,24 @@
 import { describe, it, assert, expect } from 'vitest';
 import { auth_code } from '$env/static/private';
 import { unpackBody } from '$lib/server/common';
-import { insertTable } from '$lib/server/db';
+import { insertTable, pool } from '$lib/server/db';
 import type { MusicalPieceInterface } from '$lib/server/common';
+
+const baseUrl = 'http://localhost:8888/api/musicalpiece';
+const divisionTagQuery = `
+	SELECT division_tag
+	FROM musical_piece_division_tag
+	WHERE musical_piece_id = $1
+`;
+const categoryTagQuery = `
+	SELECT category
+	FROM musical_piece_category_map
+	WHERE musical_piece_id = $1
+`;
 
 describe('Test MusicalPiece HTTP APIs', () => {
 	it('It should return no-auth', async () => {
-		let getResponseMusicalPiece = await fetch('http://localhost:8888/api/musicalpiece/', {
+		let getResponseMusicalPiece = await fetch(`${baseUrl}/`, {
 			method: 'POST',
 			headers: {
 				'Content-Type': 'application/json'
@@ -20,7 +32,7 @@ describe('Test MusicalPiece HTTP APIs', () => {
 			})
 		});
 		expect(getResponseMusicalPiece.status).toBe(401);
-		getResponseMusicalPiece = await fetch('http://localhost:8888/api/musicalpiece/1', {
+		getResponseMusicalPiece = await fetch(`${baseUrl}/1`, {
 			method: 'DELETE',
 			headers: {
 				'Content-Type': 'application/json'
@@ -30,7 +42,7 @@ describe('Test MusicalPiece HTTP APIs', () => {
 	});
 
 	it('It should return not-authorized', async () => {
-		let getResponseMusicalPiece = await fetch('http://localhost:8888/api/musicalpiece/', {
+		let getResponseMusicalPiece = await fetch(`${baseUrl}/`, {
 			method: 'POST',
 			headers: {
 				'Content-Type': 'application/json',
@@ -61,16 +73,13 @@ describe('Test MusicalPiece HTTP APIs', () => {
 		try {
 			const result = await insertTable('musical_piece', musicalPiece);
 			expect(getResponseMusicalPiece.status).toBe(401);
-			getResponseMusicalPiece = await fetch(
-				`http://localhost:8888/api/musicalpiece/${result.rows[0].id}`,
-				{
-					method: 'DELETE',
-					headers: {
-						'Content-Type': 'application/json',
-						Authorization: 'Bearer ffffff'
-					}
+			getResponseMusicalPiece = await fetch(`${baseUrl}/${result.rows[0].id}`, {
+				method: 'DELETE',
+				headers: {
+					'Content-Type': 'application/json',
+					Authorization: 'Bearer ffffff'
 				}
-			);
+			});
 			expect(getResponseMusicalPiece.status).toBe(401);
 		} catch {
 			expect(false).toBe(true);
@@ -78,7 +87,7 @@ describe('Test MusicalPiece HTTP APIs', () => {
 	});
 
 	it('It should error when required fields are not present', async () => {
-		const createResponseMusicalPiece = await fetch('http://localhost:8888/api/musicalpiece/', {
+		const createResponseMusicalPiece = await fetch(`${baseUrl}/`, {
 			method: 'POST',
 			headers: {
 				'Content-Type': 'application/json',
@@ -98,7 +107,7 @@ describe('Test MusicalPiece HTTP APIs', () => {
 	});
 
 	it('It should create and destroy musicalpiece', async () => {
-		const createResponse = await fetch('http://localhost:8888/api/musicalpiece/', {
+		const createResponse = await fetch(`${baseUrl}/`, {
 			method: 'POST',
 			headers: {
 				'Content-Type': 'application/json',
@@ -121,7 +130,7 @@ describe('Test MusicalPiece HTTP APIs', () => {
 			const resultObject = JSON.parse(bodyFromRequest);
 			const newId = resultObject.id;
 			expect(+newId).toBeGreaterThan(0);
-			const delResponse = await fetch(`http://localhost:8888/api/musicalpiece/${newId}`, {
+			const delResponse = await fetch(`${baseUrl}/${newId}`, {
 				method: 'DELETE',
 				headers: {
 					'Content-Type': 'application/json',
@@ -132,5 +141,168 @@ describe('Test MusicalPiece HTTP APIs', () => {
 		} else {
 			assert(false, 'unable to parse body of create musicalpiece request');
 		}
+	});
+
+	it('It should handle musicalpiece tag updates and removals', async () => {
+		const createResponse = await fetch(`${baseUrl}/`, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				Authorization: `Bearer ${auth_code}`
+			},
+			body: JSON.stringify({
+				printed_name: 'Tagged Piece',
+				first_contributor_id: 1,
+				all_movements: 'Movement 1',
+				second_contributor_id: 2,
+				third_contributor_id: 3,
+				division_tags: ['Piano', 'Piano'],
+				category_tags: ['Solo']
+			})
+		});
+		expect(createResponse.status).toBe(201);
+
+		if (createResponse.body == null) {
+			assert(false, 'unable to parse body of create musicalpiece request');
+			return;
+		}
+
+		const bodyFromRequest = await unpackBody(createResponse.body);
+		const resultObject = JSON.parse(bodyFromRequest);
+		const newId = Number(resultObject.id);
+		expect(newId).toBeGreaterThan(0);
+
+		const divisionResult = await pool.query(divisionTagQuery, [newId]);
+		expect(divisionResult.rows.length).toBe(1);
+		expect(divisionResult.rows[0].division_tag).toBe('Piano');
+
+		const categoryResult = await pool.query(categoryTagQuery, [newId]);
+		expect(categoryResult.rows.length).toBe(1);
+		expect(categoryResult.rows[0].category).toBe('Solo');
+
+		const removeDivisionResponse = await fetch(`${baseUrl}/${newId}`, {
+			method: 'PUT',
+			headers: {
+				'Content-Type': 'application/json',
+				Authorization: `Bearer ${auth_code}`
+			},
+			body: JSON.stringify({
+				printed_name: 'Tagged Piece',
+				first_contributor_id: 1,
+				all_movements: 'Movement 1',
+				second_contributor_id: 2,
+				third_contributor_id: 3,
+				rm_division_tags: ['Piano']
+			})
+		});
+		expect(removeDivisionResponse.status).toBe(200);
+
+		const divisionAfterRemoval = await pool.query(divisionTagQuery, [newId]);
+		expect(divisionAfterRemoval.rows.length).toBe(0);
+
+		const removeCategoryResponse = await fetch(`${baseUrl}/${newId}`, {
+			method: 'PUT',
+			headers: {
+				'Content-Type': 'application/json',
+				Authorization: `Bearer ${auth_code}`
+			},
+			body: JSON.stringify({
+				printed_name: 'Tagged Piece',
+				first_contributor_id: 1,
+				all_movements: 'Movement 1',
+				second_contributor_id: 2,
+				third_contributor_id: 3,
+				rm_category_tags: ['Solo']
+			})
+		});
+		expect(removeCategoryResponse.status).toBe(200);
+
+		const categoryAfterRemoval = await pool.query(categoryTagQuery, [newId]);
+		expect(categoryAfterRemoval.rows.length).toBe(0);
+
+		const delResponse = await fetch(`${baseUrl}/${newId}`, {
+			method: 'DELETE',
+			headers: {
+				'Content-Type': 'application/json',
+				Authorization: `Bearer ${auth_code}`
+			}
+		});
+		expect(delResponse.status).toBe(200);
+	});
+
+	it('It should reject invalid tag values and invalid removals', async () => {
+		const invalidCreateResponse = await fetch(`${baseUrl}/`, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				Authorization: `Bearer ${auth_code}`
+			},
+			body: JSON.stringify({
+				printed_name: 'Invalid Tag Piece',
+				first_contributor_id: 1,
+				division_tags: ['Brass']
+			})
+		});
+		expect(invalidCreateResponse.status).toBe(400);
+
+		const invalidCategoryResponse = await fetch(`${baseUrl}/`, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				Authorization: `Bearer ${auth_code}`
+			},
+			body: JSON.stringify({
+				printed_name: 'Invalid Category Mix',
+				first_contributor_id: 1,
+				category_tags: ['Not Appropriate', 'Solo']
+			})
+		});
+		expect(invalidCategoryResponse.status).toBe(400);
+
+		const createResponse = await fetch(`${baseUrl}/`, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				Authorization: `Bearer ${auth_code}`
+			},
+			body: JSON.stringify({
+				printed_name: 'Not Appropriate Piece',
+				first_contributor_id: 1,
+				category_tags: ['Not Appropriate']
+			})
+		});
+		expect(createResponse.status).toBe(201);
+
+		if (createResponse.body == null) {
+			assert(false, 'unable to parse body of create musicalpiece request');
+			return;
+		}
+
+		const bodyFromRequest = await unpackBody(createResponse.body);
+		const resultObject = JSON.parse(bodyFromRequest);
+		const newId = Number(resultObject.id);
+
+		const invalidRemovalResponse = await fetch(`${baseUrl}/${newId}`, {
+			method: 'PUT',
+			headers: {
+				'Content-Type': 'application/json',
+				Authorization: `Bearer ${auth_code}`
+			},
+			body: JSON.stringify({
+				printed_name: 'Not Appropriate Piece',
+				first_contributor_id: 1,
+				rm_category_tags: ['Not Appropriate']
+			})
+		});
+		expect(invalidRemovalResponse.status).toBe(400);
+
+		const delResponse = await fetch(`${baseUrl}/${newId}`, {
+			method: 'DELETE',
+			headers: {
+				'Content-Type': 'application/json',
+				Authorization: `Bearer ${auth_code}`
+			}
+		});
+		expect(delResponse.status).toBe(200);
 	});
 });

--- a/tasks/refactor-musicalpiece-tags/final-phase.md
+++ b/tasks/refactor-musicalpiece-tags/final-phase.md
@@ -1,0 +1,44 @@
+# Final Phase — Hardening, Verification, and Closeout
+
+## Documentation updates
+- [x] README updates: none expected.
+- [x] ADRs (if any): none expected.
+- [x] Inline docs/comments: add brief UI note or inline comment if multi-tag
+  overwrite behavior needs clarification.
+
+## Testing closeout
+- [x] Missing cases to add: ensure invalid tag values and "Not Appropriate"
+  exclusivity are covered.
+- [x] Coverage gaps: UI behavior is manual-only (dropdown + note).
+
+## Full verification
+> Use the pinned commands in spec + `./codex-commands.md`.
+
+- [x] Lint: `npm run lint`
+- [x] Build: `npm run build`
+- [x] Tests: `npm run test`
+
+## Manual QA (if applicable)
+- [x] Steps: open `/admin/musicalpiece`, verify dropdowns, save updates, observe
+  note.
+- [x] Expected: saves succeed and tags are reflected in subsequent loads.
+
+## Code review checklist
+- [x] Correctness and edge cases
+- [x] Error handling / failure modes
+- [x] Security (secrets, injection, authz/authn)
+- [x] Performance (DB queries, hot paths, batching)
+- [x] Maintainability (structure, naming, boundaries)
+- [x] Consistency with repo conventions
+- [x] Test quality and determinism
+
+## Release / rollout notes (if applicable)
+- [x] Migration plan: none.
+- [x] Feature flags: none.
+- [x] Backout plan: revert API/UI changes if needed.
+
+## Outstanding issues (if any)
+For each issue include severity + repro + suggested fix.
+- Severity: low
+- Repro: tag updates in POST/PUT are not wrapped in a single DB transaction.
+- Suggested fix: optionally wrap musical_piece insert/update + tag updates in a single transaction to avoid partial writes.

--- a/tasks/refactor-musicalpiece-tags/phase-1.md
+++ b/tasks/refactor-musicalpiece-tags/phase-1.md
@@ -1,0 +1,34 @@
+# Phase 1 — Tag Parsing + Admin Data Shaping
+
+## Objective
+Prepare shared tag parsing/validation utilities and load tag data for the admin
+UI without changing API behavior yet.
+
+## Code areas impacted
+- `src/lib/server/review.ts`
+- `src/routes/admin/musicalpiece/+page.server.ts`
+
+## Work items
+- [ ] Add helper(s) to parse/deduplicate tag arrays and validate against enum
+  lists.
+- [ ] Add data loading for division/category tags in the admin loader and shape
+  single-select defaults.
+- [ ] Document how multi-tag data is represented in the UI model (first sorted
+  tag).
+
+## Deliverables
+- Tag parsing/validation helper(s) ready for API use.
+- Admin loader returns tag fields usable by the UI dropdowns.
+
+## Gate (must pass before proceeding)
+- [ ] Helpers return only valid, deduped tags and capture invalid tag values.
+- [ ] Admin loader returns a stable single-tag value for each piece (or null)
+  without errors.
+
+## Verification steps
+- [ ] Command: `npm run lint`
+  - Expected: no lint errors.
+
+## Risks and mitigations
+- Risk: Loader queries impact performance for large datasets.
+- Mitigation: Use aggregated queries and avoid per-row queries where possible.

--- a/tasks/refactor-musicalpiece-tags/phase-2.md
+++ b/tasks/refactor-musicalpiece-tags/phase-2.md
@@ -1,0 +1,39 @@
+# Phase 2 — API Tag Updates + Validation
+
+## Objective
+Update musicalpiece POST/PUT to accept optional tag arrays, validate them, and
+write to tag tables.
+
+## Code areas impacted
+- `src/routes/api/musicalpiece/+server.ts`
+- `src/routes/api/musicalpiece/[id]/+server.ts`
+- `src/lib/server/review.ts`
+- `src/test/api/musicalpiece-api.test.ts`
+
+## Work items
+- [ ] Parse `division_tags` and `category_tags` from request bodies.
+- [ ] Validate tags against enum lists; dedupe values before insert/update.
+- [ ] Enforce "Not Appropriate" exclusivity with 4xx error on mixed category
+  requests.
+- [ ] Support `rm_division_tags` and `rm_category_tags` on PUT with validation
+  and exclusivity rules.
+- [ ] Insert/update tag tables alongside musical_piece create/update.
+- [ ] Add API test coverage for valid tags, invalid tags, and exclusivity
+  errors.
+
+## Deliverables
+- API endpoints accept optional tag arrays and write to tag tables.
+- Updated tests covering tag validation and exclusivity rules.
+
+## Gate (must pass before proceeding)
+- [ ] API requests with valid tags succeed and persist tags.
+- [ ] Invalid tags or mixed "Not Appropriate" category requests return 4xx
+  without partial updates.
+
+## Verification steps
+- [ ] Command: `npm run test`
+  - Expected: musicalpiece API tests pass.
+
+## Risks and mitigations
+- Risk: Partial updates if tag insert fails after musical_piece update.
+- Mitigation: Validate upfront and consider transaction scope for tag writes.

--- a/tasks/refactor-musicalpiece-tags/phase-3.md
+++ b/tasks/refactor-musicalpiece-tags/phase-3.md
@@ -1,0 +1,33 @@
+# Phase 3 — Admin UI Tag Controls
+
+## Objective
+Expose single-select category/division controls in the admin UI with clear
+messaging about API-only multi-tag support.
+
+## Code areas impacted
+- `src/routes/admin/musicalpiece/+page.svelte`
+- `src/routes/admin/musicalpiece/+page.server.ts`
+- `src/lib/constants/review.ts`
+
+## Work items
+- [ ] Add dropdowns for Category and Division tags in the add/edit UI.
+- [ ] Include a UI note about API-only multi-tag updates and overwrite behavior.
+- [ ] Ensure save payload includes single tag values as arrays for API
+  consistency.
+- [ ] Ensure add form includes tag fields (single-select) to create tags at
+  insert time.
+
+## Deliverables
+- Admin UI supports single-select tag updates and displays guidance note.
+
+## Gate (must pass before proceeding)
+- [ ] Tag dropdowns render and save without breaking existing fields.
+- [ ] UI note about multi-tag API-only behavior is visible.
+
+## Verification steps
+- [ ] Command: `npm run lint`
+  - Expected: no lint errors.
+
+## Risks and mitigations
+- Risk: UI overwrites multi-tag data without warning.
+- Mitigation: Prominent UI note and default to first tag only.

--- a/tasks/refactor-musicalpiece-tags/spec.md
+++ b/tasks/refactor-musicalpiece-tags/spec.md
@@ -1,0 +1,143 @@
+# Refactor Musical Piece Tags
+
+## Overview
+Add Division and Category tag handling to the musicalpiece API and the admin
+musical piece UI while honoring existing database constraints, including the
+"Not Appropriate" trigger behavior.
+
+## Goals
+- Accept optional division/category tag updates in `src/routes/api/musicalpiece`
+  (create + update).
+- Deduplicate tags per musical piece and validate tag values against existing
+  enums.
+- Enforce the "Not Appropriate" category exclusivity with a 4xx error when mixed
+  with other categories.
+- Support tag removals on PUT via `rm_division_tags` and `rm_category_tags`.
+- Update the admin UI to allow single-select category/division tags, with a note
+  that multi-tag updates are API-only.
+- Maintain backward compatibility for existing clients unless explicitly
+  approved.
+
+## Non-goals
+- No changes to `src/routes/api/import`.
+- No schema migrations or enum changes.
+- No multi-tag UI editing beyond a single-select dropdown.
+- No changes to review queue logic outside of shared helpers.
+
+## Use cases / user stories
+- API client can create a musical piece with one or more division tags and one
+  or more category tags.
+- API client can update tags for an existing musical piece with validation and
+  deduplication.
+- Admin user can select a single category and division tag for a musical piece
+  via UI.
+- Admin user understands multi-tag behavior is API-only and may overwrite
+  existing tags.
+
+## Current behavior
+- Musical piece API (`src/routes/api/musicalpiece/+server.ts`,
+  `src/routes/api/musicalpiece/[id]/+server.ts`) only inserts/updates the
+  `musical_piece` table; tag tables are not updated.
+- Admin UI (`src/routes/admin/musicalpiece/+page.svelte`,
+  `src/routes/admin/musicalpiece/+page.server.ts`) lists musical pieces with no
+  tag fields.
+- Tag tables (`database/init.sql`) exist with enums `piece_category` and
+  `division_tag` plus triggers enforcing "Not Appropriate".
+- Tag helpers exist in `src/lib/server/review.ts` for validation and tag
+  updates.
+
+## Proposed behavior
+- Musicalpiece POST/PUT accepts optional `division_tags` and `category_tags`
+  fields.
+  - Input accepts arrays of strings (deduped before insert/update).
+  - If `category_tags` includes `'Not Appropriate'` with any other category,
+    return 4xx and do not apply updates.
+  - Invalid tag values return 4xx with a clear reason.
+  - If tags are omitted, existing tags remain unchanged (PUT) or no tags are
+    created (POST).
+- Musicalpiece PUT accepts optional `rm_division_tags` and `rm_category_tags`
+  fields.
+  - Removal arrays are deduped and validated; invalid values return 4xx.
+  - `rm_category_tags` cannot remove `'Not Appropriate'`; attempts return 4xx.
+  - `rm_category_tags` and `rm_division_tags` cannot be combined with
+    `division_tags` or `category_tags` in the same request.
+  - Empty removal arrays are treated as no-ops.
+- Admin UI shows dropdowns for a single Category and Division tag per piece.
+  - A UI note explains multi-tag updates are API-only and saving from UI will
+    replace tags with the selected single value.
+  - When existing DB data contains multiple tags, the UI will display the first
+    tag (sorted) and the note clarifies overwrite behavior.
+
+## Technical design
+### Architecture / modules impacted
+- `src/routes/api/musicalpiece/+server.ts` (POST create)
+- `src/routes/api/musicalpiece/[id]/+server.ts` (PUT update)
+- `src/lib/server/review.ts` (reuse validation + setters)
+- `src/routes/admin/musicalpiece/+page.server.ts` (load tags for UI)
+- `src/routes/admin/musicalpiece/+page.svelte` (single-select controls + note)
+- `src/test/api/musicalpiece-api.test.ts` (new API validation coverage)
+
+### API changes (if any)
+- Request body additions (optional):
+  - `division_tags`: string[] (values in `division_tag` enum)
+  - `category_tags`: string[] (values in `piece_category` enum)
+  - `rm_division_tags`: string[] (values in `division_tag` enum, PUT only)
+  - `rm_category_tags`: string[] (values in `piece_category` enum, PUT only)
+- Responses unchanged except for new 4xx validation errors when tags are invalid
+  or "Not Appropriate" is combined with other categories.
+- Explicit permission required before finalizing these contract changes.
+
+### UI/UX changes (if any)
+- Add single-select dropdowns for Category and Division tags.
+- Add a note: multi-tag updates are API-only; UI will replace tags with the
+  chosen single selection.
+
+### Data model / schema changes (PostgreSQL)
+- Migrations: none.
+- Backward compatibility: tag tables already exist; API updates use existing
+  tables and triggers.
+- Rollback: revert API/UI changes; no DB rollback needed.
+
+## Security & privacy
+- Keep existing auth checks on musicalpiece API.
+- Validate tags against enum lists to prevent invalid values from reaching the
+  database.
+
+## Observability (logs/metrics)
+- No new logging required; consider adding minimal error messages in 4xx
+  responses for invalid tags.
+
+## Verification Commands
+> Pin the exact commands discovered for this repo (also update
+> `./codex-commands.md`).
+
+- Lint:
+  - `npm run lint`
+- Build:
+  - `npm run build`
+- Test:
+  - `npm run test`
+
+## Test strategy
+- Unit: validation helpers for tags (if extracted).
+- Integration: update `src/test/api/musicalpiece-api.test.ts` to cover tag
+  insert/validation.
+- E2E / UI: manual check in admin page for dropdowns and note.
+
+## Acceptance criteria checklist
+- [ ] POST `/api/musicalpiece` inserts division/category tag rows when provided
+  and valid.
+- [ ] PUT `/api/musicalpiece/[id]` replaces tags when provided; leaves tags
+  untouched when omitted.
+- [ ] PUT `/api/musicalpiece/[id]` removes tags when `rm_*` fields are provided
+  and valid.
+- [ ] Division tags are deduplicated; invalid values return 4xx.
+- [ ] Category tags are deduplicated; invalid values return 4xx.
+- [ ] Requests containing `category_tags` with `'Not Appropriate'` plus other
+  categories return 4xx.
+- [ ] Requests with `rm_*` fields combined with `division_tags` or
+  `category_tags` return 4xx.
+- [ ] Requests attempting to remove `'Not Appropriate'` return 4xx.
+- [ ] Admin UI shows single-select dropdowns for Category and Division tags with
+  a note about API-only multi-tag support.
+- [ ] No changes to `src/routes/api/import`.


### PR DESCRIPTION
## Overview
Add Division and Category tag handling to the musicalpiece API and the admin
musical piece UI while honoring existing database constraints, including the
"Not Appropriate" trigger behavior.

## Goals
- Accept optional division/category tag updates in `src/routes/api/musicalpiece`
  (create + update).
- Deduplicate tags per musical piece and validate tag values against existing
  enums.
- Enforce the "Not Appropriate" category exclusivity with a 4xx error when mixed
  with other categories.
- Support tag removals on PUT via `rm_division_tags` and `rm_category_tags`.
- Update the admin UI to allow single-select category/division tags, with a note
  that multi-tag updates are API-only.
- Maintain backward compatibility for existing clients unless explicitly
  approved.

## Non-goals
- No changes to `src/routes/api/import`.
- No schema migrations or enum changes.
- No multi-tag UI editing beyond a single-select dropdown.
- No changes to review queue logic outside of shared helpers.

## Use cases / user stories
- API client can create a musical piece with one or more division tags and one
  or more category tags.
- API client can update tags for an existing musical piece with validation and
  deduplication.
- Admin user can select a single category and division tag for a musical piece
  via UI.
- Admin user understands multi-tag behavior is API-only and may overwrite
  existing tags.

## Current behavior
- Musical piece API (`src/routes/api/musicalpiece/+server.ts`,
  `src/routes/api/musicalpiece/[id]/+server.ts`) only inserts/updates the
  `musical_piece` table; tag tables are not updated.
- Admin UI (`src/routes/admin/musicalpiece/+page.svelte`,
  `src/routes/admin/musicalpiece/+page.server.ts`) lists musical pieces with no
  tag fields.
- Tag tables (`database/init.sql`) exist with enums `piece_category` and
  `division_tag` plus triggers enforcing "Not Appropriate".
- Tag helpers exist in `src/lib/server/review.ts` for validation and tag
  updates.

## Proposed behavior
- Musicalpiece POST/PUT accepts optional `division_tags` and `category_tags`
  fields.
  - Input accepts arrays of strings (deduped before insert/update).
  - If `category_tags` includes `'Not Appropriate'` with any other category,
    return 4xx and do not apply updates.
  - Invalid tag values return 4xx with a clear reason.
  - If tags are omitted, existing tags remain unchanged (PUT) or no tags are
    created (POST).
- Musicalpiece PUT accepts optional `rm_division_tags` and `rm_category_tags`
  fields.
  - Removal arrays are deduped and validated; invalid values return 4xx.
  - `rm_category_tags` cannot remove `'Not Appropriate'`; attempts return 4xx.
  - `rm_category_tags` and `rm_division_tags` cannot be combined with
    `division_tags` or `category_tags` in the same request.
  - Empty removal arrays are treated as no-ops.
- Admin UI shows dropdowns for a single Category and Division tag per piece.
  - A UI note explains multi-tag updates are API-only and saving from UI will
    replace tags with the selected single value.
  - When existing DB data contains multiple tags, the UI will display the first
    tag (sorted) and the note clarifies overwrite behavior.

## Technical design
### Architecture / modules impacted
- `src/routes/api/musicalpiece/+server.ts` (POST create)
- `src/routes/api/musicalpiece/[id]/+server.ts` (PUT update)
- `src/lib/server/review.ts` (reuse validation + setters)
- `src/routes/admin/musicalpiece/+page.server.ts` (load tags for UI)
- `src/routes/admin/musicalpiece/+page.svelte` (single-select controls + note)
- `src/test/api/musicalpiece-api.test.ts` (new API validation coverage)

### API changes (if any)
- Request body additions (optional):
  - `division_tags`: string[] (values in `division_tag` enum)
  - `category_tags`: string[] (values in `piece_category` enum)
  - `rm_division_tags`: string[] (values in `division_tag` enum, PUT only)
  - `rm_category_tags`: string[] (values in `piece_category` enum, PUT only)
- Responses unchanged except for new 4xx validation errors when tags are invalid
  or "Not Appropriate" is combined with other categories.
- Explicit permission required before finalizing these contract changes.

### UI/UX changes (if any)
- Add single-select dropdowns for Category and Division tags.
- Add a note: multi-tag updates are API-only; UI will replace tags with the
  chosen single selection.

### Data model / schema changes (PostgreSQL)
- Migrations: none.
- Backward compatibility: tag tables already exist; API updates use existing
  tables and triggers.
- Rollback: revert API/UI changes; no DB rollback needed.

## Security & privacy
- Keep existing auth checks on musicalpiece API.
- Validate tags against enum lists to prevent invalid values from reaching the
  database.

## Observability (logs/metrics)
- No new logging required; consider adding minimal error messages in 4xx
  responses for invalid tags.

## Verification Commands
> Pin the exact commands discovered for this repo (also update
> `./codex-commands.md`).

- Lint:
  - `npm run lint`
- Build:
  - `npm run build`
- Test:
  - `npm run test`

## Test strategy
- Unit: validation helpers for tags (if extracted).
- Integration: update `src/test/api/musicalpiece-api.test.ts` to cover tag
  insert/validation.
- E2E / UI: manual check in admin page for dropdowns and note.

## Acceptance criteria checklist
- [ ] POST `/api/musicalpiece` inserts division/category tag rows when provided
  and valid.
- [ ] PUT `/api/musicalpiece/[id]` replaces tags when provided; leaves tags
  untouched when omitted.
- [ ] PUT `/api/musicalpiece/[id]` removes tags when `rm_*` fields are provided
  and valid.
- [ ] Division tags are deduplicated; invalid values return 4xx.
- [ ] Category tags are deduplicated; invalid values return 4xx.
- [ ] Requests containing `category_tags` with `'Not Appropriate'` plus other
  categories return 4xx.
- [ ] Requests with `rm_*` fields combined with `division_tags` or
  `category_tags` return 4xx.
- [ ] Requests attempting to remove `'Not Appropriate'` return 4xx.
- [ ] Admin UI shows single-select dropdowns for Category and Division tags with
  a note about API-only multi-tag support.
- [ ] No changes to `src/routes/api/import`.
