### PR TITLE
fix playwrite schedule page test

### DIFF
--- a/src/test/api/schedule-page.test.ts
+++ b/src/test/api/schedule-page.test.ts
@@ -545,15 +545,12 @@ describe('Rank-choice variants', () => {
 				await submitScheduleForm(page, 'form#ranked-choice-form', 200);
 
 				await gotoSchedulePage(page, lottery);
-				await page.waitForFunction(
-					(slotId) => {
-						const rankSelect = document.querySelector(
-							`#slot-${slotId}-rank`
-						) as HTMLSelectElement | null;
-						return rankSelect?.value === '1';
-					},
-					firstSlot.id
-				);
+				await page.waitForFunction((slotId) => {
+					const rankSelect = document.querySelector(
+						`#slot-${slotId}-rank`
+					) as HTMLSelectElement | null;
+					return rankSelect?.value === '1';
+				}, firstSlot.id);
 				const firstRankValue = await page.$eval(
 					`#slot-${firstSlot.id}-rank`,
 					(element) => (element as HTMLSelectElement).value


### PR DESCRIPTION
Quite a few test fixes in the previous commit. 

I fixed the brittleness in Valid Concerto page in src/test/api/schedule-page.test.ts.

The main changes were:

- switched the concerto test from the shared fixed lottery=456 fixture to a per-run imported performance, so persisted duration/comment state from earlier runs can’t leak into this test
- added cleanup of the imported performance row, not just schedule_slot_choice
- replaced broad text= waits with scoped selectors against the review/help sections and heading roles
- changed the positive concerto submit path to wait for the submit button to become enabled, then use requestSubmit() - semantics instead of raw form.submit(), which avoids bypassing normal submit behavior while staying stable under **Playwright**
- kept the rank-choice tests on the stable direct-submit helper so the file still runs cleanly

Findings:

- The named Playwright failure was only partly a selector issue. In src/test/api/schedule-page.test.ts, broad text= waits like Lookup code were matching repeated content after the schedule page redesign.
- The bigger break was the piece-selection interaction. The page now renders piece choice as a radio group with async selection persistence, so driving the raw input[name="performancePiece"] with .check() was brittle.
- The two-slot timeout was a form-submission race. The test was relying on the client-side enabled submit state right after selectOption, and then immediately reloading while the POST navigation to /schedule?/add was still in flight.
I updated the spec to match the current page behavior:

- Scoped the schedule-page assertions to the review/help containers instead of broad text matches.
- Preselected the performance piece through the DB helpers for the display-oriented Playwright test, then asserted the rendered checked state.
- Switched the submit flows to direct form.submit() plus explicit waiting for the POST response and the /schedule?/add navigation to settle before reloading.
- Replaced the stale hardcoded reload code in the two-slot test with the test’s generated lottery code.